### PR TITLE
Add README note on zipping mod releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ A minimal `modinfo.json` might look like:
 
 Important fields include `type` (one of `theme`, `content`, or `code`), `modid` which must be lowercase alphanumerics only, `version` using semantic versioning, and optional dependency entries.
 
+## Creating zip releases for testing
+
+Whenever you start a new mod or make changes to an existing one, create a zip archive so testers can easily try it out. Zip the **contents** of the mod folder, not the folder itself, so the archive contains `assets/`, `modinfo.json`, and any compiled files.
+
+From inside your mod folder run, for example:
+
+```bash
+zip -r mymod-1.0.0.zip assets modinfo.json
+```
+
+Upload the resulting zip with your release or share it directly so players can drop it into their `Mods` directory.
+
 ## Asset system overview
 
 Most game content is loaded from asset JSON files. The official *Asset System* documentation lists many categories, including:


### PR DESCRIPTION
## Summary
- update root README with instructions to create a downloadable zip whenever a mod is created or updated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68505e9cd7808323bd4ad2a1729b9509