### PR TITLE
Add planned landforms

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/patches/landformConfig.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/patches/landformConfig.json
@@ -3,8 +3,40 @@
     "op": "add",
     "path": "/landforms/-",
     "value": {
-      "code": "sheercliffcanyon",
-      "weight": 40
+      "code": "flatlands",
+      "weight": 30
+    }
+  },
+  {
+    "op": "add",
+    "path": "/landforms/-",
+    "value": {
+      "code": "sheercliffs",
+      "weight": 25
+    }
+  },
+  {
+    "op": "add",
+    "path": "/landforms/-",
+    "value": {
+      "code": "canyons",
+      "weight": 50
+    }
+  },
+  {
+    "op": "add",
+    "path": "/landforms/-",
+    "value": {
+      "code": "towercliffs",
+      "weight": 15
+    }
+  },
+  {
+    "op": "add",
+    "path": "/landforms/-",
+    "value": {
+      "code": "riceplateaus",
+      "weight": 50
     }
   }
 ]

--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/patches/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/patches/landforms.json
@@ -3,11 +3,164 @@
         "op": "add",
         "path": "/landforms/-",
         "value": {
-            "code": "sheercliffcanyon",
-            "baseHeight": 0.02,
+            "code": "canyons",
+            "baseHeight": 0.05,
             "noiseScale": 0.0015,
             "threshold": 0.92,
-            "heightOffset": 0.78,
+            "heightOffset": 0.88,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            }
+        }
+    }
+,
+    {
+        "op": "add",
+        "path": "/landforms/-",
+        "value": {
+            "code": "flatlands",
+            "baseHeight": 0.03,
+            "noiseScale": 0.002,
+            "threshold": 0.5,
+            "heightOffset": 0.75,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "op": "add",
+        "path": "/landforms/-",
+        "value": {
+            "code": "sheercliffs",
+            "baseHeight": 0.06,
+            "noiseScale": 0.001,
+            "threshold": 0.95,
+            "heightOffset": 0.9,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "op": "add",
+        "path": "/landforms/-",
+        "value": {
+            "code": "towercliffs",
+            "baseHeight": 0.04,
+            "noiseScale": 0.001,
+            "threshold": 0.97,
+            "heightOffset": 0.92,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "op": "add",
+        "path": "/landforms/-",
+        "value": {
+            "code": "riceplateaus",
+            "baseHeight": 0.05,
+            "noiseScale": 0.002,
+            "threshold": 0.6,
+            "heightOffset": 0.85,
             "genClimate": true,
             "genRockStrata": true,
             "genStructures": false,

--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/patches/survival-worldgen-storystructures.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/patches/survival-worldgen-storystructures.json
@@ -2,7 +2,35 @@
   {
     "op": "replace",
     "path": "/structures/0/requireLandform",
-    "value": "sheercliffcanyon",
+    "value": "flatlands",
+    "file": "game:worldgen/storystructures.json",
+    "side": "Server"
+  },
+  {
+    "op": "replace",
+    "path": "/structures/1/requireLandform",
+    "value": "canyons",
+    "file": "game:worldgen/storystructures.json",
+    "side": "Server"
+  },
+  {
+    "op": "replace",
+    "path": "/structures/2/requireLandform",
+    "value": "riceplateaus",
+    "file": "game:worldgen/storystructures.json",
+    "side": "Server"
+  },
+  {
+    "op": "replace",
+    "path": "/structures/3/requireLandform",
+    "value": "sheercliffs",
+    "file": "game:worldgen/storystructures.json",
+    "side": "Server"
+  },
+  {
+    "op": "replace",
+    "path": "/structures/4/requireLandform",
+    "value": "towercliffs",
     "file": "game:worldgen/storystructures.json",
     "side": "Server"
   }

--- a/WorldgenMod/FixedCliffs/modinfo.json
+++ b/WorldgenMod/FixedCliffs/modinfo.json
@@ -1,10 +1,10 @@
 {
   "type": "content",
   "modid": "fixedcliffs",
-  "name": "Fixed Sheer Cliffs",
+  "name": "Fixed Cliffs Landforms",
   "version": "1.0.0",
   "authors": ["sapje16"],
-  "description": "Adds a shear cliff canyon landform with correct patching.",
+  "description": "Adds several custom landforms including flatlands, sheer cliffs, canyons, tower cliffs and rice plateaus.",
   "dependencies": {
     "game": "1.20.12"
   }


### PR DESCRIPTION
## Summary
- expand FixedCliffs modinfo description
- add planned landforms to `landforms.json`
- assign weights in `landformConfig.json`
- allow story structures to spawn on all new landforms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685068c66f3c8323b3504ee5d639c0e6