### PR TITLE
Fix landform teleport compile errors

### DIFF
--- a/TeleportLandformMod/src/LandformTeleportSystem.cs
+++ b/TeleportLandformMod/src/LandformTeleportSystem.cs
@@ -1,6 +1,8 @@
 using Vintagestory.API.Common;
 using Vintagestory.API.Server;
 using Vintagestory.API.MathTools;
+using Vintagestory.API.Common.CommandAbbr;
+using Vintagestory.ServerMods;
 using System;
 
 namespace LandformTeleport
@@ -12,9 +14,10 @@ namespace LandformTeleport
         public override void StartServerSide(ICoreServerAPI api)
         {
             this.sapi = api;
+            var parsers = api.ChatCommands.Parsers;
             api.ChatCommands.Create("tpl")
                 .WithDesc("Teleport to nearest landform")
-                .WithArgs(api.ChatCommands.Parsers.Parsers["string"]("landform"))
+                .WithArgs(parsers.Word("landform"))
                 .HandleWith(OnTeleportCommand);
         }
 
@@ -25,27 +28,29 @@ namespace LandformTeleport
                 return TextCommandResult.Error("Command can only be used by a player.");
             }
 
-            string landformCode = args[0];
+            string landformCode = args[0] as string;
             Vec3d startPos = args.Caller.Entity.Pos.XYZ;
 
-            Vec3d? target = FindNearestLandform(startPos, landformCode);
+            Vec3d target = FindNearestLandform(startPos, landformCode);
 
             if (target == null)
             {
                 return TextCommandResult.Error("Landform not found nearby");
             }
 
-            args.Caller.Player.TeleportTo(target.Value);
+            args.Caller.Entity?.TeleportToDouble(target.X, target.Y, target.Z);
             return TextCommandResult.Success("Teleported to {0}", landformCode);
         }
 
         // NOTE: This is a placeholder search using worldgen API. Adjust as needed
-        private Vec3d? FindNearestLandform(Vec3d startPos, string landformCode)
+        private Vec3d FindNearestLandform(Vec3d startPos, string landformCode)
         {
             // The worldgen API provides access to landform maps via MapRegion and MapChunk.
             // Search nearby chunks (within 20 chunks) for matching landform index.
             int searchRadiusChunks = 20;
             int chunkSize = sapi.WorldManager.ChunkSize;
+            int regionSize = sapi.WorldManager.RegionSize;
+            int chunksPerRegion = regionSize / chunkSize;
             int originChunkX = (int)startPos.X / chunkSize;
             int originChunkZ = (int)startPos.Z / chunkSize;
 
@@ -60,12 +65,22 @@ namespace LandformTeleport
 
                         IMapChunk mapChunk = sapi.WorldManager.GetMapChunk(cx, cz);
                         if (mapChunk == null) continue;
-                        string code = mapChunk.LandformCode;
+
+                        int regionX = cx / chunksPerRegion;
+                        int regionZ = cz / chunksPerRegion;
+                        IMapRegion region = sapi.WorldManager.GetMapRegion(regionX, regionZ);
+                        if (region == null) continue;
+
+                        int lx = cx % chunksPerRegion;
+                        int lz = cz % chunksPerRegion;
+                        int index = region.LandformMap.GetInt(lx, lz);
+                        string code = NoiseLandforms.landforms.LandFormsByIndex[index].Code.Path;
+
                         if (code == landformCode)
                         {
                             double x = (cx + 0.5) * chunkSize;
                             double z = (cz + 0.5) * chunkSize;
-                            double y = sapi.World.BlockAccessor.GetTerrainMapheightAt((int)x, (int)z);
+                            double y = sapi.World.BlockAccessor.GetTerrainMapheightAt(new BlockPos((int)x, 0, (int)z));
                             return new Vec3d(x, y + 1, z);
                         }
                     }


### PR DESCRIPTION
## Summary
- use command helper methods with proper namespaces
- cast chat args and use entity teleport
- resolve landforms via region maps

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685072b8bc6883239a65d69c87e878db