### PR TITLE
Fix Teleport mod compile issues

### DIFF
--- a/TeleportLandformMod/src/LandformTeleportSystem.cs
+++ b/TeleportLandformMod/src/LandformTeleportSystem.cs
@@ -35,7 +35,7 @@ namespace LandformTeleport
                 return TextCommandResult.Error("Command can only be used by a player.");
             }
 
-            string landformCode = args[0];
+            string landformCode = (string)args[0];
             Vec3d startPos = args.Caller.Entity.Pos.XYZ;
 
             Vec3d target = FindNearestLandform(startPos, landformCode);
@@ -87,7 +87,7 @@ namespace LandformTeleport
                         {
                             double x = (cx + 0.5) * chunkSize;
                             double z = (cz + 0.5) * chunkSize;
-                            double y = sapi.World.BlockAccessor.GetTerrainMapheightAt((int)x, (int)z, false);
+                            double y = sapi.World.BlockAccessor.GetTerrainMapheightAt((int)x, (int)z);
                             return new Vec3d(x, y + 1, z);
                         }
                     }


### PR DESCRIPTION
## Summary
- handle chat command argument as a string
- call terrain height API with two parameters

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685142de5c10832398633328857c55e6