### PR TITLE
Fix Teleport mod height retrieval

### DIFF
--- a/TeleportLandformMod/src/LandformTeleportSystem.cs
+++ b/TeleportLandformMod/src/LandformTeleportSystem.cs
@@ -87,7 +87,9 @@ namespace LandformTeleport
                         {
                             double x = (cx + 0.5) * chunkSize;
                             double z = (cz + 0.5) * chunkSize;
-                            double y = sapi.World.BlockAccessor.GetTerrainMapheightAt((int)x, (int)z);
+                            // API update in Vintage Story v1.20.12 renamed this method
+                            // from GetTerrainMapheightAt to GetTerrainMapHeightAt
+                            double y = sapi.World.BlockAccessor.GetTerrainMapHeightAt((int)x, (int)z);
                             return new Vec3d(x, y + 1, z);
                         }
                     }


### PR DESCRIPTION
## Summary
- update TeleportLandformMod to use `GetTerrainMapHeightAt`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68514667e2e883239549a5416c89d472