### PR TITLE
Remove noise image assets

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -1,0 +1,30 @@
+import json
+import os
+from noise import pnoise2
+from PIL import Image
+
+PATCH_FILE = "WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/patches/landforms.json"
+OUTPUT_DIR = "WorldgenMod/noise_samples"
+SIZE = 256
+
+with open(PATCH_FILE) as f:
+    patch_data = json.load(f)
+
+landforms = [entry.get("value") for entry in patch_data if isinstance(entry, dict)]
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+for lf in landforms:
+    if not lf:
+        continue
+    code = lf.get("code")
+    scale = lf.get("noiseScale", 0.001)
+    img = Image.new("L", (SIZE, SIZE))
+    pixels = []
+    for y in range(SIZE):
+        for x in range(SIZE):
+            n = pnoise2(x * scale * 1000, y * scale * 1000, octaves=4)
+            val = int((n + 0.5) * 255)
+            pixels.append(val)
+    img.putdata(pixels)
+    img.save(os.path.join(OUTPUT_DIR, f"{code}.png"))
+    print("Saved", code)

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -84,3 +84,10 @@ The mod aims to implement the following terrain types:
 
 Each landform will generate separately. When a new world is created, approximately 85% of terrain should come from these new landforms and the remaining 15% from vanilla ones. Structures from the `story` set will be able to spawn on all new landforms if configured in `survival-worldgen-storystructures.json`.
 
+## Noise Samples
+
+The `generate_noise_images.py` helper script renders example Perlin noise maps
+using the `noiseScale` values from `landforms.json`. Run the script with
+Python to generate 256×256 PNG images in a local `WorldgenMod/noise_samples/`
+directory. These preview images are not tracked in version control.
+


### PR DESCRIPTION
## Summary
- delete generated noise sample PNGs from worldgen mod
- note that noise samples are not committed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685149d06e6c83239e23a37bd01097c2