### PR TITLE
Fix path handling in noise generator

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -3,8 +3,17 @@ import os
 from noise import pnoise2
 from PIL import Image
 
-PATCH_FILE = "WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/patches/landforms.json"
-OUTPUT_DIR = "WorldgenMod/noise_samples"
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+PATCH_FILE = os.path.join(
+    SCRIPT_DIR,
+    "FixedCliffs",
+    "assets",
+    "fixedcliffs",
+    "worldgen",
+    "patches",
+    "landforms.json",
+)
+OUTPUT_DIR = os.path.join(SCRIPT_DIR, "noise_samples")
 SIZE = 256
 
 with open(PATCH_FILE) as f:


### PR DESCRIPTION
## Summary
- make the helper script work regardless of the current working directory

## Testing
- `python WorldgenMod/generate_noise_images.py`


------
https://chatgpt.com/codex/tasks/task_b_6851644caa088323b5a3e83b59815814