### PR TITLE
Fix noise generator path

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -10,7 +10,6 @@ PATCH_FILE = os.path.join(
     "assets",
     "fixedcliffs",
     "worldgen",
-    "patches",
     "landforms.json",
 )
 OUTPUT_DIR = os.path.join(SCRIPT_DIR, "noise_samples")
@@ -19,7 +18,7 @@ SIZE = 256
 with open(PATCH_FILE) as f:
     patch_data = json.load(f)
 
-landforms = [entry.get("value") for entry in patch_data if isinstance(entry, dict)]
+landforms = patch_data.get("landforms", [])
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 for lf in landforms:


### PR DESCRIPTION
## Summary
- fix path in `generate_noise_images.py` so script runs
- parse landform definitions from asset file

## Testing
- `python3 WorldgenMod/generate_noise_images.py`

------
https://chatgpt.com/codex/tasks/task_b_685169f7f65c8323a4e85b69fa16646b