### PR TITLE
Add advanced parameters for custom landforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ When starting a new mod from scratch, first create a dedicated folder inside thi
 ## Example mods
 - **Fixed Cliffs Landforms** (`WorldgenMod/FixedCliffs`)
 - **Landform Teleport** (`TeleportLandformMod`)
+The fixed-cliffs example now includes richer parameters like `terrainOctaves`
+and `terrainYKeyPositions` that control the resulting landform shapes.
 ## Supported Vintage Story version
 
 According to the [Vintage Story wiki main page](https://wiki.vintagestory.at/Main_Page), the latest stable release is **version 1.20.12** (June 8, 2025) `Purely stable performance`.

--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -24,7 +24,19 @@
           { "rock": "andesite", "thickness": 3 },
           { "rock": "basalt", "thickness": 3 }
         ]
-      }
+      },
+      "terrainOctaves":          [0, 0, 0, 0, 0, 1, 1, 1, 0],
+      "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "terrainYKeyPositions":    [0.431, 0.436, 0.457, 0.462, 0.484, 0.489, 0.513, 0.518, 0.525],
+      "terrainYKeyThresholds":   [0.999, 0.814, 0.816, 0.761, 0.760, 0.719, 0.718, 0.688, 0.000],
+      "mutations": [
+        {
+          "code": "canyon-cavemut",
+          "chance": 0.15,
+          "terrainYKeyPositions":  [0.399, 0.419, 0.427, 0.437, 0.457, 0.462, 0.484, 0.489, 0.513, 0.518, 0.525],
+          "terrainYKeyThresholds": [1.000, 0.816, 0.035, 0.808, 0.816, 0.761, 0.760, 0.719, 0.718, 0.688, 0.000]
+        }
+      ]
     },
     {
       "code": "flatlands",
@@ -49,7 +61,11 @@
           { "rock": "andesite", "thickness": 3 },
           { "rock": "basalt", "thickness": 3 }
         ]
-      }
+      },
+      "terrainOctaves":          [0, 0, 0, 0.2, 0.3, 0, 1, 0.01, 0.01],
+      "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.4, 0, 0],
+      "terrainYKeyPositions":    [0.000, 0.425, 0.450, 0.455],
+      "terrainYKeyThresholds":   [1.000, 1.000, 0.400, 0.000]
     },
     {
       "code": "sheercliffs",
@@ -74,7 +90,11 @@
           { "rock": "andesite", "thickness": 3 },
           { "rock": "basalt", "thickness": 3 }
         ]
-      }
+      },
+      "terrainOctaves":          [0, 0.1, 0.2, 0.3, 1.0, 0.4, 0.4, 0.5, 0.35],
+      "terrainOctaveThresholds": [0, 0, 0, 0, 0.3, 0, 0, 0, 0],
+      "terrainYKeyPositions":    [0, 0.42, 0.43, 0.45, 0.7, 0.75],
+      "terrainYKeyThresholds":   [1, 0.9, 0.7, 0.4, 0.1, 0]
     },
     {
       "code": "towercliffs",
@@ -99,7 +119,11 @@
           { "rock": "andesite", "thickness": 3 },
           { "rock": "basalt", "thickness": 3 }
         ]
-      }
+      },
+      "terrainOctaves":          [0, 0, 0, 0, 0.2, 0.4, 1, 0.7, 0],
+      "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0.3],
+      "terrainYKeyPositions":    [0, 0.435, 0.45, 0.5, 0.54, 0.55, 0.59, 0.6, 0.64, 0.66],
+      "terrainYKeyThresholds":   [1, 1, 0.4, 0.22, 0.21, 0.18, 0.17, 0.14, 0.13, 0]
     },
     {
       "code": "riceplateaus",
@@ -124,7 +148,11 @@
           { "rock": "andesite", "thickness": 3 },
           { "rock": "basalt", "thickness": 3 }
         ]
-      }
+      },
+      "terrainOctaves":          [0, 1, 1, 1, 1, 0, 0.25, 0.25, 0.25],
+      "terrainOctaveThresholds": [0, 0, 0, 0.5, 0, 0, 0, 0, 0],
+      "terrainYKeyPositions":    [0.432, 0.611, 0.712, 0.735, 0.885],
+      "terrainYKeyThresholds":   [1.000, 0.952, 0.660, 0.629, 0.000]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -26,12 +26,40 @@ for lf in landforms:
         continue
     code = lf.get("code")
     scale = lf.get("noiseScale", 0.001)
+    octaves = lf.get("terrainOctaves", [])
+    octave_thresholds = lf.get("terrainOctaveThresholds", [])
+    ykeys = lf.get("terrainYKeyPositions", [])
+    ythresh = lf.get("terrainYKeyThresholds", [])
+    if not octaves:
+        octaves = [1]
+    if len(octave_thresholds) < len(octaves):
+        octave_thresholds += [0] * (len(octaves) - len(octave_thresholds))
     img = Image.new("L", (SIZE, SIZE))
     pixels = []
     for y in range(SIZE):
+        ynorm = y / (SIZE - 1)
+        yfactor = 1.0
+        if ykeys and ythresh:
+            yfactor = ythresh[-1]
+            for i in range(len(ykeys) - 1):
+                if ynorm <= ykeys[i + 1]:
+                    t1 = ythresh[i]
+                    t2 = ythresh[i + 1]
+                    p1 = ykeys[i]
+                    p2 = ykeys[i + 1]
+                    ratio = 0 if p2 == p1 else (ynorm - p1) / (p2 - p1)
+                    yfactor = t1 + (t2 - t1) * ratio
+                    break
         for x in range(SIZE):
-            n = pnoise2(x * scale * 1000, y * scale * 1000, octaves=4)
-            val = int((n + 0.5) * 255)
+            total = 0.0
+            for i, amp in enumerate(octaves):
+                freq = 2 ** i
+                thr = octave_thresholds[i]
+                n = pnoise2(x * scale * freq * 1000, y * scale * freq * 1000)
+                n = max(0.0, (n + 0.5) - thr)
+                total += amp * n
+            total = max(0.0, min(total * yfactor, 1.0))
+            val = int(total * 255)
             pixels.append(val)
     img.putdata(pixels)
     img.save(os.path.join(OUTPUT_DIR, f"{code}.png"))

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -87,7 +87,8 @@ Each landform will generate separately. When a new world is created, approximate
 ## Noise Samples
 
 The `generate_noise_images.py` helper script renders example Perlin noise maps
-using the `noiseScale` values from `landforms.json`. Run the script with
-Python to generate 256×256 PNG images in a local `WorldgenMod/noise_samples/`
-directory. These preview images are not tracked in version control.
+based on the `noiseScale` plus the new octave and height arrays in
+`landforms.json`. Run the script with Python to generate 256×256 PNG images in
+a local `WorldgenMod/noise_samples/` directory. These preview images are not
+tracked in version control.
 


### PR DESCRIPTION
## Summary
- enrich landform definitions with octave and height arrays
- document new parameters in README files
- update noise preview script to use new arrays for rendering

## Testing
- `python -m py_compile WorldgenMod/generate_noise_images.py`
- `python WorldgenMod/generate_noise_images.py`

------
https://chatgpt.com/codex/tasks/task_b_6851980aea288323958d673fd516c98c