### PR TITLE
Update landform octaves

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -25,10 +25,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 0, 0, 0, 0, 1, 1, 1, 0],
+      "terrainOctaves":          [0, 0, 0, 0, 0.2, 1, 1, 0.8, 0.2],
       "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0.431, 0.436, 0.457, 0.462, 0.484, 0.489, 0.513, 0.518, 0.525],
-      "terrainYKeyThresholds":   [0.999, 0.814, 0.816, 0.761, 0.760, 0.719, 0.718, 0.688, 0.000],
+      "terrainYKeyPositions":    [0.35, 0.40, 0.45, 0.50, 0.54, 0.58, 0.62, 0.66, 0.70],
+      "terrainYKeyThresholds":   [1.000, 0.850, 0.840, 0.800, 0.790, 0.750, 0.740, 0.700, 0.000],
       "mutations": [
         {
           "code": "canyon-cavemut",
@@ -62,10 +62,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 0, 0, 0.2, 0.3, 0, 1, 0.01, 0.01],
+      "terrainOctaves":          [0, 0, 0.1, 0.15, 0.2, 0, 0.4, 0, 0],
       "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.4, 0, 0],
-      "terrainYKeyPositions":    [0.000, 0.425, 0.450, 0.455],
-      "terrainYKeyThresholds":   [1.000, 1.000, 0.400, 0.000]
+      "terrainYKeyPositions":    [0.000, 0.440, 0.460, 0.470],
+      "terrainYKeyThresholds":   [1.000, 1.000, 0.500, 0.000]
     },
     {
       "code": "sheercliffs",
@@ -91,9 +91,9 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 0.1, 0.2, 0.3, 1.0, 0.4, 0.4, 0.5, 0.35],
+      "terrainOctaves":          [0, 0.2, 0.35, 0.5, 1.2, 0.65, 0.65, 0.8, 0.6],
       "terrainOctaveThresholds": [0, 0, 0, 0, 0.3, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0, 0.42, 0.43, 0.45, 0.7, 0.75],
+      "terrainYKeyPositions":    [0, 0.40, 0.44, 0.50, 0.78, 0.83],
       "terrainYKeyThresholds":   [1, 0.9, 0.7, 0.4, 0.1, 0]
     },
     {
@@ -120,10 +120,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 0, 0, 0, 0.2, 0.4, 1, 0.7, 0],
+      "terrainOctaves":          [0, 0, 0, 0, 0.2, 0.5, 1, 0.9, 0.4],
       "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0.3],
-      "terrainYKeyPositions":    [0, 0.435, 0.45, 0.5, 0.54, 0.55, 0.59, 0.6, 0.64, 0.66],
-      "terrainYKeyThresholds":   [1, 1, 0.4, 0.22, 0.21, 0.18, 0.17, 0.14, 0.13, 0]
+      "terrainYKeyPositions":    [0, 0.45, 0.48, 0.55, 0.63, 0.70, 0.75, 0.80, 0.86, 0.90],
+      "terrainYKeyThresholds":   [1, 1, 0.45, 0.30, 0.22, 0.20, 0.18, 0.15, 0.14, 0]
     },
     {
       "code": "riceplateaus",
@@ -149,10 +149,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 1, 1, 1, 1, 0, 0.25, 0.25, 0.25],
+      "terrainOctaves":          [0, 1, 1, 1, 1, 0, 0.3, 0.3, 0.3],
       "terrainOctaveThresholds": [0, 0, 0, 0.5, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0.432, 0.611, 0.712, 0.735, 0.885],
-      "terrainYKeyThresholds":   [1.000, 0.952, 0.660, 0.629, 0.000]
+      "terrainYKeyPositions":    [0.430, 0.550, 0.650, 0.750, 0.850],
+      "terrainYKeyThresholds":   [1.000, 0.950, 0.700, 0.650, 0.000]
     }
   ]
 }

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -92,3 +92,14 @@ based on the `noiseScale` plus the new octave and height arrays in
 a local `WorldgenMod/noise_samples/` directory. These preview images are not
 tracked in version control.
 
+### Parameter notes
+
+* **terrainOctaves** – amplitude multipliers per Perlin octave. Larger numbers
+  add sharper detail at that scale.
+* **terrainYKeyPositions** – normalized height checkpoints that define where the
+  landform changes vertically.
+* **terrainYKeyThresholds** – blending values tied to each Y key that control
+  how abruptly those changes occur.
+* **threshold** – minimum noise value required for the landform to generate at a
+  given coordinate. Higher values make the feature rarer and more isolated.
+


### PR DESCRIPTION
## Summary
- adjust noise thresholds and vertical keys in landforms.json
- document new worldgen parameters in the readme

## Testing
- `pip install noise Pillow`
- `python3 WorldgenMod/generate_noise_images.py`

------
https://chatgpt.com/codex/tasks/task_b_68519e0b92b883238e50936c327c549f