### PR TITLE
Make noise preview image size configurable

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -1,5 +1,6 @@
 import json
 import os
+import argparse
 from noise import pnoise2
 from PIL import Image
 
@@ -13,9 +14,20 @@ PATCH_FILE = os.path.join(
     "landforms.json",
 )
 OUTPUT_DIR = os.path.join(SCRIPT_DIR, "noise_samples")
-SIZE = 256
 WARP_SCALE = 0.01
 WARP_AMPLITUDE = 20.0
+
+parser = argparse.ArgumentParser(
+    description="Render preview noise maps from landform definitions"
+)
+parser.add_argument(
+    "--size",
+    type=int,
+    default=256,
+    help="Width and height of the generated PNG images",
+)
+args = parser.parse_args()
+SIZE = args.size
 
 with open(PATCH_FILE) as f:
     patch_data = json.load(f)

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -88,9 +88,10 @@ Each landform will generate separately. When a new world is created, approximate
 
 The `generate_noise_images.py` helper script renders example Perlin noise maps
 based on the `noiseScale` plus the new octave and height arrays in
-`landforms.json`. Run the script with Python to generate 256×256 PNG images in
-a local `WorldgenMod/noise_samples/` directory. These preview images are not
-tracked in version control.
+`landforms.json`. Run the script with Python to generate PNG images in a local
+`WorldgenMod/noise_samples/` directory. Use `--size <N>` to set the pixel width
+and height (default 256×256) when previewing larger areas. These preview images
+are not tracked in version control.
 
 ### Parameter notes
 


### PR DESCRIPTION
## Summary
- allow `generate_noise_images.py` to take a `--size` option
- mention the CLI option in the worldgen mod readme

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6851a50fe7fc8323917c177c993ac086