### PR TITLE
Implement heightmap option for noise preview

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -26,8 +26,14 @@ parser.add_argument(
     default=256,
     help="Width and height of the generated PNG images",
 )
+parser.add_argument(
+    "--heightmap",
+    action="store_true",
+    help="Generate heightmap previews instead of cross-sections",
+)
 args = parser.parse_args()
 SIZE = args.size
+HEIGHTMAP = args.heightmap
 
 with open(PATCH_FILE) as f:
     patch_data = json.load(f)
@@ -44,42 +50,64 @@ for lf in landforms:
     octave_thresholds = lf.get("terrainOctaveThresholds", [])
     ykeys = lf.get("terrainYKeyPositions", [])
     ythresh = lf.get("terrainYKeyThresholds", [])
+    base_height = lf.get("baseHeight", 0.0)
+    height_offset = lf.get("heightOffset", 0.0)
     if not octaves:
         octaves = [1]
     if len(octave_thresholds) < len(octaves):
         octave_thresholds += [0] * (len(octaves) - len(octave_thresholds))
     img = Image.new("L", (SIZE, SIZE))
     pixels = []
-    for y in range(SIZE):
-        ynorm = y / (SIZE - 1)
-        yfactor = 1.0
-        if ykeys and ythresh:
-            yfactor = ythresh[-1]
-            for i in range(len(ykeys) - 1):
-                if ynorm <= ykeys[i + 1]:
-                    t1 = ythresh[i]
-                    t2 = ythresh[i + 1]
-                    p1 = ykeys[i]
-                    p2 = ykeys[i + 1]
-                    ratio = 0 if p2 == p1 else (ynorm - p1) / (p2 - p1)
-                    yfactor = t1 + (t2 - t1) * ratio
-                    break
-        for x in range(SIZE):
-            total = 0.0
-            warp_x = pnoise2(x * WARP_SCALE, y * WARP_SCALE) * WARP_AMPLITUDE
-            warp_z = pnoise2(x * WARP_SCALE + 1000, y * WARP_SCALE + 1000) * WARP_AMPLITUDE
-            for i, amp in enumerate(octaves):
-                freq = 2 ** i
-                thr = octave_thresholds[i]
-                raw = pnoise2((x + warp_x) * scale * freq * 1000,
-                               (y + warp_z) * scale * freq * 1000)
-                n = (raw + 1.0) * 0.5
-                n = max(0.0, n - thr)
-                n = 3 * n * n - 2 * n * n * n
-                total += amp * n
-            total = max(0.0, min(total * yfactor, 1.0))
-            val = int(total * 255)
-            pixels.append(val)
+    if HEIGHTMAP:
+        for z in range(SIZE):
+            for x in range(SIZE):
+                total = 0.0
+                warp_x = pnoise2(x * WARP_SCALE, z * WARP_SCALE) * WARP_AMPLITUDE
+                warp_z = pnoise2(x * WARP_SCALE + 1000, z * WARP_SCALE + 1000) * WARP_AMPLITUDE
+                for i, amp in enumerate(octaves):
+                    freq = 2 ** i
+                    thr = octave_thresholds[i]
+                    raw = pnoise2((x + warp_x) * scale * freq * 1000,
+                                   (z + warp_z) * scale * freq * 1000)
+                    n = (raw + 1.0) * 0.5
+                    n = max(0.0, n - thr)
+                    n = 3 * n * n - 2 * n * n * n
+                    total += amp * n
+                total = max(0.0, min(total, 1.0))
+                height = base_height + height_offset * total
+                val = int(max(0.0, min(height, 1.0)) * 255)
+                pixels.append(val)
+    else:
+        for y in range(SIZE):
+            ynorm = y / (SIZE - 1)
+            yfactor = 1.0
+            if ykeys and ythresh:
+                yfactor = ythresh[-1]
+                for i in range(len(ykeys) - 1):
+                    if ynorm <= ykeys[i + 1]:
+                        t1 = ythresh[i]
+                        t2 = ythresh[i + 1]
+                        p1 = ykeys[i]
+                        p2 = ykeys[i + 1]
+                        ratio = 0 if p2 == p1 else (ynorm - p1) / (p2 - p1)
+                        yfactor = t1 + (t2 - t1) * ratio
+                        break
+            for x in range(SIZE):
+                total = 0.0
+                warp_x = pnoise2(x * WARP_SCALE, y * WARP_SCALE) * WARP_AMPLITUDE
+                warp_z = pnoise2(x * WARP_SCALE + 1000, y * WARP_SCALE + 1000) * WARP_AMPLITUDE
+                for i, amp in enumerate(octaves):
+                    freq = 2 ** i
+                    thr = octave_thresholds[i]
+                    raw = pnoise2((x + warp_x) * scale * freq * 1000,
+                                   (y + warp_z) * scale * freq * 1000)
+                    n = (raw + 1.0) * 0.5
+                    n = max(0.0, n - thr)
+                    n = 3 * n * n - 2 * n * n * n
+                    total += amp * n
+                total = max(0.0, min(total * yfactor, 1.0))
+                val = int(total * 255)
+                pixels.append(val)
     img.putdata(pixels)
-    img.save(os.path.join(OUTPUT_DIR, f"{code}.png"))
-    print("Saved", code)
+    img.save(os.path.join(OUTPUT_DIR, f"{code}_{'heightmap' if HEIGHTMAP else 'preview'}.png"))
+    print("Saved", code, "heightmap" if HEIGHTMAP else "preview")

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -92,6 +92,8 @@ based on the `noiseScale` plus the new octave and height arrays in
 `WorldgenMod/noise_samples/` directory. Use `--size <N>` to set the pixel width
 and height (default 256×256) when previewing larger areas. These preview images
 are not tracked in version control.
+Pass the optional `--heightmap` flag to output a top‑down heightmap instead of
+the default vertical preview.
 
 ### Parameter notes
 


### PR DESCRIPTION
## Summary
- add `--heightmap` flag to `generate_noise_images.py`
- support rendering a top-down heightmap
- document the new option in the worldgen readme

## Testing
- `python -m py_compile WorldgenMod/generate_noise_images.py`
- `flake8 WorldgenMod/generate_noise_images.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851aa48c0448323bc7ff4b9d99fc339