### PR TITLE
Update noise rendering defaults

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -27,10 +27,12 @@ parser.add_argument(
     help="Width and height of the generated PNG images",
 )
 parser.add_argument(
-    "--heightmap",
-    action="store_true",
-    help="Generate heightmap previews instead of cross-sections",
+    "--cross-section",
+    dest="heightmap",
+    action="store_false",
+    help="Generate vertical cross-sections instead of a top-down heightmap",
 )
+parser.set_defaults(heightmap=True)
 args = parser.parse_args()
 SIZE = args.size
 HEIGHTMAP = args.heightmap

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -91,9 +91,8 @@ based on the `noiseScale` plus the new octave and height arrays in
 `landforms.json`. Run the script with Python to generate PNG images in a local
 `WorldgenMod/noise_samples/` directory. Use `--size <N>` to set the pixel width
 and height (default 256×256) when previewing larger areas. These preview images
-are not tracked in version control.
-Pass the optional `--heightmap` flag to output a top‑down heightmap instead of
-the default vertical preview.
+are not tracked in version control. By default the script outputs a top-down
+heightmap. Use the `--cross-section` flag to render a vertical preview instead.
 
 ### Parameter notes
 


### PR DESCRIPTION
## Summary
- switch `--heightmap` flag to `--cross-section` in `generate_noise_images.py`
- document new default behavior that heightmaps are generated unless `--cross-section` is passed

## Testing
- `python WorldgenMod/generate_noise_images.py --help | head`
- `python WorldgenMod/generate_noise_images.py --size 8`
- `python WorldgenMod/generate_noise_images.py --size 8 --cross-section`

------
https://chatgpt.com/codex/tasks/task_b_6851b01ff51083238131360ae76e1f6d