### PR TITLE
Fix landformConfig patch target

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/landformConfig.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/landformConfig.json
@@ -2,6 +2,8 @@
   {
     "op": "add",
     "path": "/landforms/flatlands",
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server",
     "value": {
       "weight": 1446
     }
@@ -9,6 +11,8 @@
   {
     "op": "add",
     "path": "/landforms/sheercliffs",
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server",
     "value": {
       "weight": 2891
     }
@@ -16,6 +20,8 @@
   {
     "op": "add",
     "path": "/landforms/canyons",
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server",
     "value": {
       "weight": 3614
     }
@@ -23,6 +29,8 @@
   {
     "op": "add",
     "path": "/landforms/towercliffs",
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server",
     "value": {
       "weight": 2168
     }
@@ -30,6 +38,8 @@
   {
     "op": "add",
     "path": "/landforms/riceplateaus",
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server",
     "value": {
       "weight": 7950
     }


### PR DESCRIPTION
## Summary
- add missing `file` and `side` fields to landform weight patch

## Testing
- `python3 WorldgenMod/generate_noise_images.py --size 16` *(fails: ModuleNotFoundError: No module named 'noise')*

------
https://chatgpt.com/codex/tasks/task_b_6852dbbce1a48323a10fdcae0eb5a782