### PR TITLE
Fix landform JSON and update FixedCliffs worldgen

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -1,6 +1,6 @@
 {
-  "replace": false,
-  "landforms": [
+  "code": "landforms",
+  "variants": [
     {
       "code": "canyons",
       "baseHeight": 0.2,
@@ -154,5 +154,6 @@
       "terrainYKeyPositions":    [0.430, 0.550, 0.650, 0.750, 0.850],
       "terrainYKeyThresholds":   [1.000, 0.950, 0.700, 0.650, 0.000]
     }
-  ]
+  ],
+  "replace": false
 }

--- a/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
+++ b/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
@@ -2,6 +2,7 @@ using Vintagestory.API.Common;
 using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
 using Vintagestory.API.Datastructures;
+using Vintagestory.API.Util;
 using System.Collections.Generic;
 
 namespace FixedCliffs
@@ -14,9 +15,9 @@ namespace FixedCliffs
     public class FixedCliffsWorldGen : ModSystem
     {
         ICoreServerAPI sapi;
-        INoise mainNoise;
-        INoise warpNoiseX;
-        INoise warpNoiseZ;
+        FastNoiseLite mainNoise;
+        FastNoiseLite warpNoiseX;
+        FastNoiseLite warpNoiseZ;
 
         public override void StartServerSide(ICoreServerAPI api)
         {
@@ -27,11 +28,11 @@ namespace FixedCliffs
         private void InitWorldGen()
         {
             int seed = sapi.WorldManager.Seed;
-            mainNoise = new PerlinNoise(seed, 3);
-            warpNoiseX = new PerlinNoise(seed + 1, 1);
-            warpNoiseZ = new PerlinNoise(seed + 2, 1);
+            mainNoise = new FastNoiseLite(seed) { NoiseType = FastNoiseLite.NoiseType.OpenSimplex2 }; 
+            warpNoiseX = new FastNoiseLite(seed + 1) { NoiseType = FastNoiseLite.NoiseType.OpenSimplex2 }; 
+            warpNoiseZ = new FastNoiseLite(seed + 2) { NoiseType = FastNoiseLite.NoiseType.OpenSimplex2 }; 
 
-            sapi.WorldManager.ChunkGenerator.RegisterChunkColumnModifier(GenChunkColumn);
+            sapi.WorldManager.ChunkGen.RegisterChunkColumnModifier(GenChunkColumn);
         }
 
         private void GenChunkColumn(IServerChunk[] chunks, int chunkX, int chunkZ)

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -40,7 +40,7 @@ HEIGHTMAP = args.heightmap
 with open(PATCH_FILE) as f:
     patch_data = json.load(f)
 
-landforms = patch_data.get("landforms", [])
+landforms = patch_data.get("variants", [])
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
 


### PR DESCRIPTION
## Summary
- fix incorrect worldgen landform format
- update noise image script for new structure
- modernise FixedCliffs worldgen code

## Testing
- `python -m py_compile WorldgenMod/generate_noise_images.py`


------
https://chatgpt.com/codex/tasks/task_b_6852dedae3e88323ba5cf533868ec4a1