### PR TITLE
Improve canyon paths and raise rice plateaus

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -4,9 +4,9 @@
     {
       "code": "canyons",
       "baseHeight": 0.2,
-      "noiseScale": 0.00075,
-      "threshold": 0.92,
-      "heightOffset": 0.65,
+      "noiseScale": 0.0004,
+      "threshold": 0.25,
+      "heightOffset": 0.80,
       "genClimate": true,
       "genRockStrata": true,
       "genStructures": false,
@@ -25,10 +25,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 0, 0, 0, 0.2, 1, 1, 0.8, 0.2],
+      "terrainOctaves":          [0, 0, 0, 0.15, 0.3, 1, 1, 0.6, 0.2],
       "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0.35, 0.40, 0.45, 0.50, 0.54, 0.58, 0.62, 0.66, 0.70],
-      "terrainYKeyThresholds":   [1.000, 0.850, 0.840, 0.800, 0.790, 0.750, 0.740, 0.700, 0.000],
+      "terrainYKeyPositions":    [0.00, 0.40, 0.60, 0.80, 0.90, 0.95],
+      "terrainYKeyThresholds":   [0.0, 0.0, 0.85, 1.0, 1.0, 1.0],
       "mutations": [
         {
           "code": "canyon-cavemut",
@@ -128,9 +128,9 @@
     {
       "code": "riceplateaus",
       "baseHeight": 0.25,
-      "noiseScale": 0.00025,
-      "threshold": 0.8,
-      "heightOffset": 0.55,
+      "noiseScale": 0.00015,
+      "threshold": 0.5,
+      "heightOffset": 0.75,
       "genClimate": true,
       "genRockStrata": true,
       "genStructures": false,
@@ -149,10 +149,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 1, 1, 1, 1, 0, 0.3, 0.3, 0.3],
+      "terrainOctaves":          [0, 0.6, 0.6, 1, 1, 0.2, 0.1, 0.1, 0],
       "terrainOctaveThresholds": [0, 0, 0, 0.5, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0.430, 0.550, 0.650, 0.750, 0.850],
-      "terrainYKeyThresholds":   [1.000, 0.950, 0.700, 0.650, 0.000]
+      "terrainYKeyPositions":    [0.35, 0.60, 0.75, 0.90, 1.00],
+      "terrainYKeyThresholds":   [1.000, 1.000, 1.000, 0.95, 0.000]
     }
   ],
   "replace": false

--- a/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
+++ b/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
@@ -74,13 +74,13 @@ namespace FixedCliffs
                 new LandformParams
                 {
                     BaseHeight = 0.2f,
-                    NoiseScale = 0.00075f,
-                    Threshold = 0.92f,
-                    HeightOffset = 0.65f,
-                    TerrainOctaves = new float[] {0f,0f,0f,0f,0.2f,1f,1f,0.8f,0.2f},
+                    NoiseScale = 0.0004f,
+                    Threshold = 0.25f,
+                    HeightOffset = 0.80f,
+                    TerrainOctaves = new float[] {0f,0f,0f,0.15f,0.3f,1f,1f,0.6f,0.2f},
                     TerrainOctaveThresholds = new float[] {0f,0f,0f,0f,0f,0f,0f,0f,0f},
-                    TerrainYKeyPositions = new float[] {0.35f,0.40f,0.45f,0.50f,0.54f,0.58f,0.62f,0.66f,0.70f},
-                    TerrainYKeyThresholds = new float[] {1f,0.850f,0.840f,0.800f,0.790f,0.750f,0.740f,0.700f,0f}
+                    TerrainYKeyPositions = new float[] {0f,0.40f,0.60f,0.80f,0.90f,0.95f},
+                    TerrainYKeyThresholds = new float[] {0f,0f,0.85f,1f,1f,1f}
                 },
                 new LandformParams
                 {
@@ -96,13 +96,13 @@ namespace FixedCliffs
                 new LandformParams
                 {
                     BaseHeight = 0.25f,
-                    NoiseScale = 0.00025f,
-                    Threshold = 0.8f,
-                    HeightOffset = 0.55f,
-                    TerrainOctaves = new float[] {0f,1f,1f,1f,1f,0f,0.3f,0.3f,0.3f},
+                    NoiseScale = 0.00015f,
+                    Threshold = 0.5f,
+                    HeightOffset = 0.75f,
+                    TerrainOctaves = new float[] {0f,0.6f,0.6f,1f,1f,0.2f,0.1f,0.1f,0f},
                     TerrainOctaveThresholds = new float[] {0f,0f,0f,0.5f,0f,0f,0f,0f,0f},
-                    TerrainYKeyPositions = new float[] {0.430f,0.550f,0.650f,0.750f,0.850f},
-                    TerrainYKeyThresholds = new float[] {1f,0.950f,0.700f,0.650f,0f}
+                    TerrainYKeyPositions = new float[] {0.35f,0.60f,0.75f,0.90f,1.00f},
+                    TerrainYKeyThresholds = new float[] {1f,1f,1f,0.95f,0f}
                 }
             };
 

--- a/perlin
+++ b/perlin
@@ -32,9 +32,9 @@ The table below lists representative parameter choices from `FixedCliffs/landfor
 |---------------|-----------|----------|---------------|
 | `flatlands`    | `0.001`   | `0.5`    | Gentle height changes. Terrain octaves emphasize smooth slopes.
 | `sheercliffs`  | `0.0005`  | `0.95`   | High threshold and strong octaves create abrupt walls.
-| `canyons`      | `0.00075` | `0.92`   | Steep drops with additional mutation for caves.
+| `canyons`      | `0.0004`  | `0.25`   | Tall plateaus broken by thin, winding paths.
 | `towercliffs`  | `0.0005`  | `0.97`   | Multiple octaves focus noise near the top to form pillars.
-| `riceplateaus` | `0.00025` | `0.8`    | Low scale with stacked Y keys for terraced levels.
+| `riceplateaus` | `0.00015` | `0.5`    | High tiered shelves with sheer walls and flat tops.
 
 Adjusting these values changes how often a landform appears and how dramatic its features look. Lower the threshold to spread a shape farther across the world. Increase specific octave amplitudes to add jagged details at different sizes.
 


### PR DESCRIPTION
## Summary
- further tune canyon parameters for continuous narrow paths
- raise rice plateau shelves with steeper walls
- update Perlin reference table

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6852e94351788323a3f6842f40443df8