### PR TITLE
Improve canyon and rice plateau landforms

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -4,7 +4,7 @@
     {
       "code": "canyons",
       "baseHeight": 0.2,
-      "noiseScale": 0.0005,
+      "noiseScale": 0.00025,
       "threshold": 0.2,
       "heightOffset": 0.75,
       "genClimate": true,
@@ -25,10 +25,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 0, 0.1, 0.2, 0.4, 1, 1, 0.8, 0.3],
-      "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0.00, 0.35, 0.55, 0.70, 0.80, 0.90],
-      "terrainYKeyThresholds":   [0.0, 0.0, 0.8, 1.0, 1.0, 1.0],
+      "terrainOctaves":          [0.1, 0.2, 0.4, 0.6, 1, 0.8, 0.4],
+      "terrainOctaveThresholds": [0, 0, 0, 0.4, 0.6, 0.8, 1],
+      "terrainYKeyPositions":    [0.00, 0.25, 0.45, 0.65, 0.85, 0.95],
+      "terrainYKeyThresholds":   [0, 0, 0.9, 1, 1, 1],
       "mutations": [
         {
           "code": "canyon-cavemut",
@@ -130,7 +130,7 @@
       "baseHeight": 0.20,
       "noiseScale": 0.0002,
       "threshold": 0.4,
-      "heightOffset": 0.60,
+      "heightOffset": 0.80,
       "genClimate": true,
       "genRockStrata": true,
       "genStructures": false,
@@ -150,9 +150,9 @@
         ]
       },
       "terrainOctaves":          [0, 0.8, 0.8, 1, 1, 0.4, 0.2, 0.1, 0.1],
-      "terrainOctaveThresholds": [0, 0, 0, 0.4, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0.40, 0.55, 0.70, 0.85, 1.00],
-      "terrainYKeyThresholds":   [1.000, 1.000, 0.800, 0.600, 0.000]
+      "terrainOctaveThresholds": [0, 0, 0, 0.5, 0.3, 0, 0, 0, 0],
+      "terrainYKeyPositions":    [0.45, 0.65, 0.85, 1.05],
+      "terrainYKeyThresholds":   [1, 1, 1, 0]
     }
   ],
   "replace": false

--- a/WorldgenMod/terrain_generation_guide.md
+++ b/WorldgenMod/terrain_generation_guide.md
@@ -91,6 +91,32 @@ Adjust weights in `landformConfig.json` to prioritize dramatic formations:
 
 ---
 
+## 📏 Landform Tuning Guidelines
+
+* **noiseScale** – lower values stretch patterns horizontally, creating wider canyons or plateaus.
+* **terrainOctaves** – early high values keep large, flat platforms while later octaves add detail.
+* **terrainYKeyPositions/Thresholds** – pair together to form vertical steps or gentle slopes.
+
+Example parameters:
+
+```json
+"canyons": {
+  "noiseScale": 0.00025,
+  "terrainOctaves": [0.1, 0.2, 0.4, 0.6, 1, 0.8, 0.4],
+  "terrainYKeyPositions": [0.00, 0.25, 0.45, 0.65, 0.85, 0.95],
+  "terrainYKeyThresholds": [0, 0, 0.9, 1, 1, 1]
+},
+"riceplateaus": {
+  "heightOffset": 0.8,
+  "terrainYKeyPositions": [0.45, 0.65, 0.85, 1.05],
+  "terrainYKeyThresholds": [1, 1, 1, 0]
+}
+```
+
+These tweaks widen canyon floors and raise terrace heights for easier building.
+
+---
+
 ## ✅ Final Notes
 
 - Avoid abrupt vertical jumps without plateaus (makes terrain unplayable)


### PR DESCRIPTION
## Summary
- tweak `canyons` landform for longer pathways with smoother walls
- raise `riceplateaus` terraces and add vertical thresholds
- document how to tune landform parameters in `terrain_generation_guide.md`

## Testing
- `python3 -m json.tool WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json`
- `python3 WorldgenMod/generate_noise_images.py --help` *(fails: ModuleNotFoundError: No module named 'opensimplex')*

------
https://chatgpt.com/codex/tasks/task_b_6852ef9fba908323b15b515dd7ae9148