### PR TITLE
Fix worldgen mod compile errors

### DIFF
--- a/WorldgenMod/FixedCliffs/src/FastNoiseLite.cs
+++ b/WorldgenMod/FixedCliffs/src/FastNoiseLite.cs
@@ -21,7 +21,7 @@ namespace FixedCliffs
             OpenSimplex2
         }
 
-        public NoiseType NoiseType { get; set; }
+        public NoiseType CurrentNoiseType { get; set; }
 
         public float GetNoise(float x, float y)
         {

--- a/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
+++ b/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
@@ -44,9 +44,9 @@ namespace FixedCliffs
         private void InitWorldGen()
         {
             int seed = sapi.WorldManager.Seed;
-            mainNoise = new FastNoiseLite(seed) { NoiseType = FastNoiseLite.NoiseType.OpenSimplex2 };
-            warpNoiseX = new FastNoiseLite(seed + 1) { NoiseType = FastNoiseLite.NoiseType.OpenSimplex2 };
-            warpNoiseZ = new FastNoiseLite(seed + 2) { NoiseType = FastNoiseLite.NoiseType.OpenSimplex2 };
+            mainNoise = new FastNoiseLite(seed) { CurrentNoiseType = FastNoiseLite.NoiseType.OpenSimplex2 };
+            warpNoiseX = new FastNoiseLite(seed + 1) { CurrentNoiseType = FastNoiseLite.NoiseType.OpenSimplex2 };
+            warpNoiseZ = new FastNoiseLite(seed + 2) { CurrentNoiseType = FastNoiseLite.NoiseType.OpenSimplex2 };
 
 
             LoadLandforms();


### PR DESCRIPTION
## Summary
- rename `NoiseType` property in FastNoiseLite to avoid name clash
- update worldgen to use the new property name

## Testing
- `grep -i error -n WorldgenMod/server-main.log | head -n 5`

------
https://chatgpt.com/codex/tasks/task_b_68531ac69448832386e9795b3a6b6d6d