### PR TITLE
Add setup script for repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python virtual environment
+env/
+__pycache__/
+*.pyc
+
+# Generated noise preview images
+WorldgenMod/noise_samples/
+
+# Misc
+*.log

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ A minimal `modinfo.json` might look like:
 
 Important fields include `type` (one of `theme`, `content`, or `code`), `modid` which must be lowercase alphanumerics only, `version` using semantic versioning, and optional dependency entries.
 
+## Environment setup
+
+Run `./setup_env.sh` to create a Python virtual environment and install the
+dependencies listed in `requirements.txt`. The script will also report whether
+the `dotnet` CLI is available, which is needed for compiling the C# example
+mods.
+
 ## Asset system overview
 
 Most game content is loaded from asset JSON files. The official *Asset System* documentation lists many categories, including:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+opensimplex
+Pillow

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create Python virtual environment if it doesn't exist
+if [ ! -d "env" ]; then
+    python3 -m venv env
+fi
+
+# Activate the virtual environment
+source env/bin/activate
+
+# Upgrade pip and install Python dependencies
+pip install --upgrade pip
+pip install -r requirements.txt
+
+echo "Python dependencies installed."
+
+# Verify .NET SDK
+if ! command -v dotnet > /dev/null 2>&1; then
+    echo "dotnet CLI not found. Please install the .NET SDK for building C# mods."
+else
+    echo "dotnet CLI detected: $(dotnet --version)"
+fi


### PR DESCRIPTION
## Summary
- add `.gitignore`
- add `setup_env.sh` to prepare Python virtualenv and check for dotnet
- list Python requirements
- document environment setup in README

## Testing
- `bash -n setup_env.sh`
- `./setup_env.sh > /tmp/setup_env.log`
- `python -m py_compile WorldgenMod/generate_noise_images.py`

------
https://chatgpt.com/codex/tasks/task_b_6853e860faf88323a22cb126fdd47f0e