### PR TITLE
Improve setup script with offline package fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ Important fields include `type` (one of `theme`, `content`, or `code`), `modid` 
 ## Environment setup
 
 Run `./setup_env.sh` to create a Python virtual environment and install the
-dependencies listed in `requirements.txt`. The script will also report whether
-the `dotnet` CLI is available, which is needed for compiling the C# example
-mods.
+dependencies listed in `requirements.txt`. The script first attempts to fetch
+packages from PyPI. If network access is blocked, you can place pre-downloaded
+wheel files in a `wheels/` directory and the script will install from there.
+The script also reports whether the `dotnet` CLI is available, which is needed
+for compiling the C# example mods.
 
 ## Asset system overview
 

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -11,7 +11,15 @@ source env/bin/activate
 
 # Upgrade pip and install Python dependencies
 pip install --upgrade pip
-pip install -r requirements.txt
+if ! pip install -r requirements.txt; then
+    if [ -d "wheels" ]; then
+        echo "Network install failed. Attempting offline install from ./wheels" >&2
+        pip install --no-index --find-links ./wheels -r requirements.txt
+    else
+        echo "Package installation failed and no ./wheels directory found" >&2
+        exit 1
+    fi
+fi
 
 echo "Python dependencies installed."
 


### PR DESCRIPTION
## Summary
- add fallback logic in `setup_env.sh` to install from a local `wheels/` directory if the online install fails
- document the new offline install option in README

## Testing
- `./setup_env.sh`

------
https://chatgpt.com/codex/tasks/task_b_6853efbf2a708323864c23cfc248a3ae