### PR TITLE
Worldgen fixes and landform tuning

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -26,10 +26,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0.1, 0.2, 0.4, 0.6, 1, 0.8, 0.4],
+      "terrainOctaves":          [0.2, 0.3, 0.4, 0.6, 1, 0.8, 0.4],
       "terrainOctaveThresholds": [0, 0, 0, 0.4, 0.6, 0.8, 1],
       "terrainYKeyPositions":    [0.00, 0.25, 0.45, 0.65, 0.85, 0.95],
-      "terrainYKeyThresholds":   [0, 0, 0.9, 1, 1, 1],
+      "terrainYKeyThresholds":   [0, 0, 0.5, 1, 1, 1],
       "mutations": [
         {
           "code": "canyon-cavemut",
@@ -132,7 +132,7 @@
     {
       "code": "riceplateaus",
       "baseHeight": 0.20,
-      "noiseScale": 0.0002,
+      "noiseScale": 0.00015,
       "threshold": 0.4,
       "weight": 7950,
       "heightOffset": 0.80,
@@ -154,10 +154,10 @@
           { "rock": "basalt", "thickness": 3 }
         ]
       },
-      "terrainOctaves":          [0, 0.8, 0.8, 1, 1, 0.4, 0.2, 0.1, 0.1],
+      "terrainOctaves":          [0.05, 0.3, 0.3, 0.5, 0.5, 0.3, 0.15, 0.1, 0.05],
       "terrainOctaveThresholds": [0, 0, 0, 0.5, 0.3, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0.45, 0.65, 0.85, 1.05],
-      "terrainYKeyThresholds":   [1, 1, 1, 0]
+      "terrainYKeyPositions":    [0.40, 0.55, 0.70, 0.85, 1.00, 1.20],
+      "terrainYKeyThresholds":   [1, 0.85, 0.7, 0.55, 0.4, 0]
     }
   ],
   "replace": false

--- a/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
+++ b/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
@@ -99,7 +99,12 @@ namespace FixedCliffs
                     if (noiseVal < 0) continue;
 
                     int height = (int)(mapHeight * noiseVal);
-                    chunks[0].Blocks[(yindex(height) << 5) | (z << 5) | x] = 1;
+                    int chunkY = height / chunkSize;
+                    if (chunkY < 0 || chunkY >= chunks.Length) continue;
+                    int localY = height % chunkSize;
+                    IServerChunk chunk = chunks[chunkY];
+                    int index = localY * chunkSize * chunkSize + z * chunkSize + x;
+                    chunk.Blocks[index] = 1;
                 }
             }
         }

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -107,5 +107,18 @@ heightmap. Use the `--cross-section` flag to render a vertical preview instead.
 * **threshold** – minimum noise value required for the landform to generate at a
   given coordinate. Higher values make the feature rarer and more isolated.
 
+### Rice plateau layout
+
+The `riceplateaus` landform forms very large, flat steps. It now uses a small
+`noiseScale` (`0.00015`) and multiple height keys to stack terraces:
+
+```json
+"terrainYKeyPositions": [0.40, 0.55, 0.70, 0.85, 1.00, 1.20],
+"terrainYKeyThresholds": [1, 0.85, 0.7, 0.55, 0.4, 0]
+```
+
+These values leave plenty of rim space on each level for building large
+structures.
+
 
 

--- a/WorldgenMod/terrain_generation_guide.md
+++ b/WorldgenMod/terrain_generation_guide.md
@@ -73,6 +73,16 @@ This helps terrain feel less grid-aligned or uniform.
 
 ---
 
+## 🗂 Loading Landform Parameters
+
+`FixedCliffsWorldGen` reads the file `assets/fixedcliffs/worldgen/landforms.json`
+during server startup. Each object in the `variants` array becomes a
+`LandformParams` record used in `GenChunkColumn`. Tweaking values such as
+`terrainOctaves`, `terrainYKeyPositions` and `terrainYKeyThresholds` directly
+changes how sharp the cliffs appear and how terrace levels stack.
+
+---
+
 ## 🌟 Landform Balancing
 
 Adjust weights in `landformConfig.json` to prioritize dramatic formations:


### PR DESCRIPTION
## Summary
- fix incorrect chunk indexing in `FixedCliffsWorldGen`
- tweak canyon thresholds for better valleys
- redesign riceplateaus landform with stacked terraces
- document rice plateau parameters
- explain how `landforms.json` is loaded

## Testing
- `./setup_env.sh`
- `python WorldgenMod/generate_noise_images.py --size 16`

------
https://chatgpt.com/codex/tasks/task_b_6853f78517e0832383a9ae75ce8e9bfe