### PR TITLE
Update noise preview script

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -5,7 +5,7 @@ from opensimplex import OpenSimplex
 from PIL import Image
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-PATCH_FILE = os.path.join(
+DEFAULT_LANDFORMS_FILE = os.path.join(
     SCRIPT_DIR,
     "FixedCliffs",
     "assets",
@@ -38,13 +38,18 @@ parser.add_argument(
     default=0,
     help="Noise seed used for generation (default 0)",
 )
+parser.add_argument(
+    "--landforms-file",
+    default=DEFAULT_LANDFORMS_FILE,
+    help="Path to landforms JSON (default: %(default)s)",
+)
 parser.set_defaults(heightmap=True)
 args = parser.parse_args()
 SIZE = args.size
 HEIGHTMAP = args.heightmap
 SEED = args.seed
-
-with open(PATCH_FILE) as f:
+LANDFORMS_FILE = args.landforms_file
+with open(LANDFORMS_FILE) as f:
     patch_data = json.load(f)
 
 landforms = patch_data.get("variants", [])

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -89,12 +89,15 @@ Each landform will generate separately. When a new world is created, approximate
 ## Noise Samples
 
 The `generate_noise_images.py` helper script renders example Perlin noise maps
-based on the `noiseScale` plus the new octave and height arrays in
-`landforms.json`. Run the script with Python to generate PNG images in a local
-`WorldgenMod/noise_samples/` directory. Use `--size <N>` to set the pixel width
-and height (default 256×256) when previewing larger areas. These preview images
-are not tracked in version control. By default the script outputs a top-down
-heightmap. Use the `--cross-section` flag to render a vertical preview instead.
+based on the `noiseScale` plus the new octave and height arrays in a
+`landforms.json` file. By default it looks for
+`WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json`, but you
+can specify another file with `--landforms-file`. Run the script with Python to
+generate PNG images in a local `WorldgenMod/noise_samples/` directory. Use
+`--size <N>` to set the pixel width and height (default 256×256) when previewing
+larger areas. These preview images are not tracked in version control. By
+default the script outputs a top-down heightmap. Use the `--cross-section` flag
+to render a vertical preview instead.
 
 ### Parameter notes
 

--- a/perlin
+++ b/perlin
@@ -14,7 +14,7 @@ This document summarizes how to use Perlin noise parameters to replicate the lan
 - **terrainYKeyThresholds**: Blending values for the Y key positions. When used with the helper script these shape plateaus, cliffs and other vertical transitions.
 - **mutations**: Optional variations with their own octave/height settings. The `chance` field indicates how frequently the mutation appears.
 
-The `generate_noise_images.py` script reads these fields from `worldgen/landforms.json` and previews the resulting maps.
+The `generate_noise_images.py` script reads these fields from a `landforms.json` file (by default `WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json`). You can pass a custom path using the `--landforms-file` option to preview other terrain setups.
 
 ## Example Landforms
 


### PR DESCRIPTION
## Summary
- allow generate_noise_images.py to load landforms from a custom path
- document the new option in `perlin` and `WorldgenMod/readme`

## Testing
- `python3 -m py_compile WorldgenMod/generate_noise_images.py`

------
https://chatgpt.com/codex/tasks/task_b_6853fecb6adc8323a8c64a31b2909afd