### PR TITLE
Fix stacked plateau calculation

### DIFF
--- a/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
+++ b/WorldgenMod/FixedCliffs/src/FixedCliffsWorldGen.cs
@@ -172,7 +172,6 @@ namespace FixedCliffs
                     if (dist <= radius)
                     {
                         stepFactor = (i + 1f) / p.PlateauCount;
-                        break;
                     }
                     radius *= p.RadiusStep;
                 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -98,7 +98,6 @@ def sample_height(params, x, z):
         for i in range(plateau_count):
             if dist <= radius:
                 step_factor = (i + 1) / plateau_count
-                break
             radius *= radius_step
         if step_factor == 0.0:
             return None

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -134,7 +134,8 @@ large builds.
 
 `FixedCliffsWorldGen` reads `baseRadius`, `plateauCount`, and `radiusStep` to
 create concentric terraces. The `generate_noise_images.py` script mirrors this
-logic so the preview images match in-game terrain.
+logic so the preview images match in-game terrain. Inner plateau tiers now
+override outer ones so the terraces stack correctly.
 
 
 


### PR DESCRIPTION
## Summary
- make plateau loop check all radii so inner tiers override outer ones
- document this behavior in the worldgen readme

## Testing
- `./setup_env.sh`
- `python WorldgenMod/generate_noise_images.py --size 32`

------
https://chatgpt.com/codex/tasks/task_b_68544c979c848323acc5fa8be9f99dd3