### PR TITLE
Add new plateau and cliff landforms

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/landformConfig.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/landformConfig.json
@@ -1,7 +1,56 @@
 [
-  {"op":"add","path":"/landforms/flatlands","value":{"weight":6324},"file":"game:worldgen/landformConfig.json","side":"Server"},
-  {"op":"add","path":"/landforms/sheercliffs","value":{"weight":1084},"file":"game:worldgen/landformConfig.json","side":"Server"},
-  {"op":"add","path":"/landforms/canyons","value":{"weight":2710},"file":"game:worldgen/landformConfig.json","side":"Server"},
-  {"op":"add","path":"/landforms/towercliffs","value":{"weight":723},"file":"game:worldgen/landformConfig.json","side":"Server"},
-  {"op":"add","path":"/landforms/riceplateaus","value":{"weight":7228},"file":"game:worldgen/landformConfig.json","side":"Server"}
+    {
+        "op": "add",
+        "path": "/landforms/sinkholeplateaus",
+        "value": {
+            "weight": 2000
+        },
+        "file": "game:worldgen/landformConfig.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/landforms/dryseapillars",
+        "value": {
+            "weight": 1500
+        },
+        "file": "game:worldgen/landformConfig.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/landforms/widepillarcliffs",
+        "value": {
+            "weight": 1200
+        },
+        "file": "game:worldgen/landformConfig.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/landforms/drydeepstepmountains",
+        "value": {
+            "weight": 1000
+        },
+        "file": "game:worldgen/landformConfig.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/landforms/landstepmountains",
+        "value": {
+            "weight": 800
+        },
+        "file": "game:worldgen/landformConfig.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/landforms/terraceplateaus",
+        "value": {
+            "weight": 2000
+        },
+        "file": "game:worldgen/landformConfig.json",
+        "side": "Server"
+    }
 ]

--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/landforms.json
@@ -1,7 +1,488 @@
 [
-  {"op":"add","path":"/variants/-","value":{"code":"canyons","baseHeight":0.2,"noiseScale":0.00025,"threshold":0.2,"weight":2710,"heightOffset":0.75,"genClimate":true,"genRockStrata":true,"genStructures":false,"genVegetation":false,"climate":{"minRain":0.2,"maxRain":0.8,"minTemp":0.1,"maxTemp":0.9},"rockStrata":{"variant":"cliff","strata":[{"rock":"granite","thickness":4},{"rock":"andesite","thickness":3},{"rock":"basalt","thickness":3}]},"terrainOctaves":[0.1,0.2,0.4,0.6,1,0.8,0.4],"terrainOctaveThresholds":[0,0,0,0.4,0.6,0.8,1],"terrainYKeyPositions":[0.00,0.05,0.10,0.25,0.45,0.65,0.85,0.95],"terrainYKeyThresholds":[0,0.2,0.4,0.6,0.9,1,1,1],"mutations":[{"code":"canyon-cavemut","chance":0.15,"terrainYKeyPositions":[0.399,0.419,0.427,0.437,0.457,0.462,0.484,0.489,0.513,0.518,0.525],"terrainYKeyThresholds":[1.000,0.816,0.035,0.808,0.816,0.761,0.760,0.719,0.718,0.688,0.000]}]},"file":"game:worldgen/landforms.json","side":"Server"},
-  {"op":"add","path":"/variants/-","value":{"code":"flatlands","baseHeight":0.2,"noiseScale":0.001,"threshold":0.5,"weight":6324,"heightOffset":0.55,"genClimate":true,"genRockStrata":true,"genStructures":false,"genVegetation":false,"climate":{"minRain":0.2,"maxRain":0.8,"minTemp":0.1,"maxTemp":0.9},"rockStrata":{"variant":"cliff","strata":[{"rock":"granite","thickness":4},{"rock":"andesite","thickness":3},{"rock":"basalt","thickness":3}]},"terrainOctaves":[0,0,0.1,0.15,0.2,0,0.4,0,0],"terrainOctaveThresholds":[0,0,0,0,0,0,0.4,0,0],"terrainYKeyPositions":[0.000,0.440,0.460,0.470],"terrainYKeyThresholds":[1.000,1.000,0.500,0.000]},"file":"game:worldgen/landforms.json","side":"Server"},
-  {"op":"add","path":"/variants/-","value":{"code":"sheercliffs","baseHeight":0.25,"noiseScale":0.0005,"threshold":0.95,"weight":1084,"heightOffset":0.55,"genClimate":true,"genRockStrata":true,"genStructures":false,"genVegetation":false,"climate":{"minRain":0.2,"maxRain":0.8,"minTemp":0.1,"maxTemp":0.9},"rockStrata":{"variant":"cliff","strata":[{"rock":"granite","thickness":4},{"rock":"andesite","thickness":3},{"rock":"basalt","thickness":3}]},"terrainOctaves":[0.1,0.2,0.4,0.6,1.0,0.6,0.4,0.3,0.2],"terrainOctaveThresholds":[0,0,0,0,0.3,0,0,0,0],"terrainYKeyPositions":[0.0,0.35,0.45,0.46,0.6,0.7],"terrainYKeyThresholds":[1.0,1.0,0.5,0.5,0.2,0.0]},"file":"game:worldgen/landforms.json","side":"Server"},
-  {"op":"add","path":"/variants/-","value":{"code":"towercliffs","baseHeight":0.25,"noiseScale":0.0005,"threshold":0.97,"weight":723,"heightOffset":0.55,"genClimate":true,"genRockStrata":true,"genStructures":false,"genVegetation":false,"climate":{"minRain":0.2,"maxRain":0.8,"minTemp":0.1,"maxTemp":0.9},"rockStrata":{"variant":"cliff","strata":[{"rock":"granite","thickness":4},{"rock":"andesite","thickness":3},{"rock":"basalt","thickness":3}]},"terrainOctaves":[0,0,0,0,0.2,0.5,1,0.9,0.4],"terrainOctaveThresholds":[0,0,0,0,0,0,0,0,0.3],"terrainYKeyPositions":[0,0.45,0.48,0.55,0.63,0.70,0.75,0.80,0.86,0.90],"terrainYKeyThresholds":[1,1,0.45,0.30,0.22,0.20,0.18,0.15,0.14,0]},"file":"game:worldgen/landforms.json","side":"Server"},
-  {"op":"add","path":"/variants/-","value":{"code":"riceplateaus","baseHeight":0.05,"noiseScale":0.00015,"threshold":0.4,"weight":7228,"heightOffset":0.65,"baseRadius":60,"radiusNoiseScale":0.05,"radiusNoiseAmplitude":1.0,"plateauCount":4,"radiusStep":0.75,"genClimate":true,"genRockStrata":true,"genStructures":false,"genVegetation":false,"climate":{"minRain":0.2,"maxRain":0.8,"minTemp":0.1,"maxTemp":0.9},"rockStrata":{"variant":"cliff","strata":[{"rock":"granite","thickness":4},{"rock":"andesite","thickness":3},{"rock":"basalt","thickness":3}]},"terrainOctaves":[0.05,0.3,0.3,0.5,0.5,0.3,0.15,0.1,0.05],"terrainOctaveThresholds":[0,0,0,0.5,0.3,0,0,0,0],"terrainYKeyPositions":[0.20,0.40,0.60,0.80],"terrainYKeyThresholds":[1,0.9,0.7,0]},"file":"game:worldgen/landforms.json","side":"Server"}
+    {
+        "op": "add",
+        "path": "/variants/-",
+        "value": {
+            "code": "sinkholeplateaus",
+            "baseHeight": 0.2,
+            "noiseScale": 0.0003,
+            "threshold": 0.3,
+            "weight": 2000,
+            "heightOffset": 0.7,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+                1,
+                1,
+                0
+            ],
+            "terrainOctaveThresholds": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "terrainYKeyPositions": [
+                0.4,
+                0.42,
+                0.46,
+                0.5,
+                0.54,
+                0.58,
+                0.62,
+                0.65,
+                0.67
+            ],
+            "terrainYKeyThresholds": [
+                1.0,
+                0.9,
+                0.85,
+                0.75,
+                0.7,
+                0.65,
+                0.6,
+                0.55,
+                0
+            ]
+        },
+        "file": "game:worldgen/landforms.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/variants/-",
+        "value": {
+            "code": "dryseapillars",
+            "baseHeight": 0.25,
+            "noiseScale": 0.0004,
+            "threshold": 0.6,
+            "weight": 1500,
+            "heightOffset": 0.75,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0,
+                0,
+                0,
+                0.2,
+                0.6,
+                1,
+                0.7,
+                0.3
+            ],
+            "terrainOctaveThresholds": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0.15
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.37,
+                0.44,
+                0.52,
+                0.6,
+                0.7,
+                0.82,
+                0.88,
+                0.95
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                1,
+                0.5,
+                0.3,
+                0.25,
+                0.2,
+                0.15,
+                0.1,
+                0
+            ]
+        },
+        "file": "game:worldgen/landforms.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/variants/-",
+        "value": {
+            "code": "widepillarcliffs",
+            "baseHeight": 0.25,
+            "noiseScale": 0.00035,
+            "threshold": 0.65,
+            "weight": 1200,
+            "heightOffset": 0.6,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0,
+                0,
+                0.1,
+                0.3,
+                0.5,
+                1,
+                0.8,
+                0.3
+            ],
+            "terrainOctaveThresholds": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0.3
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.48,
+                0.53,
+                0.58,
+                0.63,
+                0.7,
+                0.78,
+                0.84,
+                0.9,
+                0.96
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                1,
+                0.45,
+                0.38,
+                0.35,
+                0.3,
+                0.25,
+                0.18,
+                0.15,
+                0
+            ]
+        },
+        "file": "game:worldgen/landforms.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/variants/-",
+        "value": {
+            "code": "drydeepstepmountains",
+            "baseHeight": 0.25,
+            "noiseScale": 0.00025,
+            "threshold": 0.4,
+            "weight": 1000,
+            "heightOffset": 0.8,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0.81,
+                0.729,
+                0.6561,
+                0.59049,
+                0.531441,
+                0.4,
+                0.2,
+                0
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.45,
+                0.55,
+                0.62,
+                0.7,
+                0.78,
+                0.86
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                0.7,
+                0.5,
+                0.35,
+                0.25,
+                0.1,
+                0
+            ]
+        },
+        "file": "game:worldgen/landforms.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/variants/-",
+        "value": {
+            "code": "landstepmountains",
+            "baseHeight": 0.25,
+            "noiseScale": 0.00025,
+            "threshold": 0.5,
+            "weight": 800,
+            "heightOffset": 0.8,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0.81,
+                0.729,
+                0.6561,
+                0,
+                0.531441,
+                0.4,
+                0.2,
+                0
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.43,
+                0.53,
+                0.6,
+                0.7,
+                0.78,
+                0.86,
+                0.92,
+                0.97
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                1,
+                0.5,
+                0.4,
+                0.3,
+                0.2,
+                0.15,
+                0.1,
+                0
+            ]
+        },
+        "file": "game:worldgen/landforms.json",
+        "side": "Server"
+    },
+    {
+        "op": "add",
+        "path": "/variants/-",
+        "value": {
+            "code": "terraceplateaus",
+            "baseHeight": 0.1,
+            "noiseScale": 0.00015,
+            "threshold": 0.45,
+            "weight": 2000,
+            "heightOffset": 0.65,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0,
+                0,
+                0.25,
+                0.3,
+                1,
+                1,
+                0.7,
+                0.15
+            ],
+            "terrainOctaveThresholds": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.4,
+                0.45,
+                0.5,
+                0.55,
+                0.6,
+                0.65,
+                0.7,
+                0.75
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                1,
+                0.7,
+                0.5,
+                0.4,
+                0.3,
+                0.2,
+                0.1,
+                0
+            ]
+        },
+        "file": "game:worldgen/landforms.json",
+        "side": "Server"
+    }
 ]

--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/survival-worldgen-storystructures.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/survival-worldgen-storystructures.json
@@ -1,37 +1,37 @@
 [
-  {
-    "op": "replace",
-    "path": "/structures/0/requireLandform",
-    "value": "flatlands",
-    "file": "game:worldgen/storystructures.json",
-    "side": "Server"
-  },
-  {
-    "op": "replace",
-    "path": "/structures/1/requireLandform",
-    "value": "canyons",
-    "file": "game:worldgen/storystructures.json",
-    "side": "Server"
-  },
-  {
-    "op": "replace",
-    "path": "/structures/2/requireLandform",
-    "value": "riceplateaus",
-    "file": "game:worldgen/storystructures.json",
-    "side": "Server"
-  },
-  {
-    "op": "replace",
-    "path": "/structures/3/requireLandform",
-    "value": "sheercliffs",
-    "file": "game:worldgen/storystructures.json",
-    "side": "Server"
-  },
-  {
-    "op": "replace",
-    "path": "/structures/4/requireLandform",
-    "value": "towercliffs",
-    "file": "game:worldgen/storystructures.json",
-    "side": "Server"
-  }
+    {
+        "op": "replace",
+        "path": "/structures/0/requireLandform",
+        "value": "terraceplateaus",
+        "file": "game:worldgen/storystructures.json",
+        "side": "Server"
+    },
+    {
+        "op": "replace",
+        "path": "/structures/1/requireLandform",
+        "value": "sinkholeplateaus",
+        "file": "game:worldgen/storystructures.json",
+        "side": "Server"
+    },
+    {
+        "op": "replace",
+        "path": "/structures/2/requireLandform",
+        "value": "drydeepstepmountains",
+        "file": "game:worldgen/storystructures.json",
+        "side": "Server"
+    },
+    {
+        "op": "replace",
+        "path": "/structures/3/requireLandform",
+        "value": "widepillarcliffs",
+        "file": "game:worldgen/storystructures.json",
+        "side": "Server"
+    },
+    {
+        "op": "replace",
+        "path": "/structures/4/requireLandform",
+        "value": "landstepmountains",
+        "file": "game:worldgen/storystructures.json",
+        "side": "Server"
+    }
 ]

--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -1,164 +1,456 @@
 {
-  "code": "landforms",
-  "variants": [
-    {
-      "code": "canyons",
-      "baseHeight": 0.2,
-      "noiseScale": 0.00025,
-      "threshold": 0.2,
-      "weight": 2710,
-      "heightOffset": 0.75,
-      "genClimate": true,
-      "genRockStrata": true,
-      "genStructures": false,
-      "genVegetation": false,
-      "climate": {
-        "minRain": 0.2,
-        "maxRain": 0.8,
-        "minTemp": 0.1,
-        "maxTemp": 0.9
-      },
-      "rockStrata": {
-        "variant": "cliff",
-        "strata": [
-          { "rock": "granite", "thickness": 4 },
-          { "rock": "andesite", "thickness": 3 },
-          { "rock": "basalt", "thickness": 3 }
-        ]
-      },
-      "terrainOctaves":          [0.2, 0.3, 0.4, 0.6, 1, 0.8, 0.4],
-      "terrainOctaveThresholds": [0, 0, 0, 0.4, 0.6, 0.8, 1],
-      "terrainYKeyPositions":    [0.00, 0.05, 0.10, 0.25, 0.45, 0.65, 0.85, 0.95],
-      "terrainYKeyThresholds":   [0, 0.2, 0.4, 0.6, 0.9, 1, 1, 1],
-      "mutations": [
+    "code": "landforms",
+    "variants": [
         {
-          "code": "canyon-cavemut",
-          "chance": 0.15,
-          "terrainYKeyPositions":  [0.399, 0.419, 0.427, 0.437, 0.457, 0.462, 0.484, 0.489, 0.513, 0.518, 0.525],
-          "terrainYKeyThresholds": [1.000, 0.816, 0.035, 0.808, 0.816, 0.761, 0.760, 0.719, 0.718, 0.688, 0.000]
+            "code": "sinkholeplateaus",
+            "baseHeight": 0.2,
+            "noiseScale": 0.0003,
+            "threshold": 0.3,
+            "weight": 2000,
+            "heightOffset": 0.7,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                1,
+                1,
+                1,
+                0
+            ],
+            "terrainOctaveThresholds": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "terrainYKeyPositions": [
+                0.4,
+                0.42,
+                0.46,
+                0.5,
+                0.54,
+                0.58,
+                0.62,
+                0.65,
+                0.67
+            ],
+            "terrainYKeyThresholds": [
+                1.0,
+                0.9,
+                0.85,
+                0.75,
+                0.7,
+                0.65,
+                0.6,
+                0.55,
+                0
+            ]
+        },
+        {
+            "code": "dryseapillars",
+            "baseHeight": 0.25,
+            "noiseScale": 0.0004,
+            "threshold": 0.6,
+            "weight": 1500,
+            "heightOffset": 0.75,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0,
+                0,
+                0,
+                0.2,
+                0.6,
+                1,
+                0.7,
+                0.3
+            ],
+            "terrainOctaveThresholds": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0.15
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.37,
+                0.44,
+                0.52,
+                0.6,
+                0.7,
+                0.82,
+                0.88,
+                0.95
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                1,
+                0.5,
+                0.3,
+                0.25,
+                0.2,
+                0.15,
+                0.1,
+                0
+            ]
+        },
+        {
+            "code": "widepillarcliffs",
+            "baseHeight": 0.25,
+            "noiseScale": 0.00035,
+            "threshold": 0.65,
+            "weight": 1200,
+            "heightOffset": 0.6,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0,
+                0,
+                0.1,
+                0.3,
+                0.5,
+                1,
+                0.8,
+                0.3
+            ],
+            "terrainOctaveThresholds": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0.3
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.48,
+                0.53,
+                0.58,
+                0.63,
+                0.7,
+                0.78,
+                0.84,
+                0.9,
+                0.96
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                1,
+                0.45,
+                0.38,
+                0.35,
+                0.3,
+                0.25,
+                0.18,
+                0.15,
+                0
+            ]
+        },
+        {
+            "code": "drydeepstepmountains",
+            "baseHeight": 0.25,
+            "noiseScale": 0.00025,
+            "threshold": 0.4,
+            "weight": 1000,
+            "heightOffset": 0.8,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0.81,
+                0.729,
+                0.6561,
+                0.59049,
+                0.531441,
+                0.4,
+                0.2,
+                0
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.45,
+                0.55,
+                0.62,
+                0.7,
+                0.78,
+                0.86
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                0.7,
+                0.5,
+                0.35,
+                0.25,
+                0.1,
+                0
+            ]
+        },
+        {
+            "code": "landstepmountains",
+            "baseHeight": 0.25,
+            "noiseScale": 0.00025,
+            "threshold": 0.5,
+            "weight": 800,
+            "heightOffset": 0.8,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0.81,
+                0.729,
+                0.6561,
+                0,
+                0.531441,
+                0.4,
+                0.2,
+                0
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.43,
+                0.53,
+                0.6,
+                0.7,
+                0.78,
+                0.86,
+                0.92,
+                0.97
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                1,
+                0.5,
+                0.4,
+                0.3,
+                0.2,
+                0.15,
+                0.1,
+                0
+            ]
+        },
+        {
+            "code": "terraceplateaus",
+            "baseHeight": 0.1,
+            "noiseScale": 0.00015,
+            "threshold": 0.45,
+            "weight": 2000,
+            "heightOffset": 0.65,
+            "genClimate": true,
+            "genRockStrata": true,
+            "genStructures": false,
+            "genVegetation": false,
+            "climate": {
+                "minRain": 0.2,
+                "maxRain": 0.8,
+                "minTemp": 0.1,
+                "maxTemp": 0.9
+            },
+            "rockStrata": {
+                "variant": "cliff",
+                "strata": [
+                    {
+                        "rock": "granite",
+                        "thickness": 4
+                    },
+                    {
+                        "rock": "andesite",
+                        "thickness": 3
+                    },
+                    {
+                        "rock": "basalt",
+                        "thickness": 3
+                    }
+                ]
+            },
+            "terrainOctaves": [
+                0,
+                0,
+                0,
+                0.25,
+                0.3,
+                1,
+                1,
+                0.7,
+                0.15
+            ],
+            "terrainOctaveThresholds": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0
+            ],
+            "terrainYKeyPositions": [
+                0.0,
+                0.4,
+                0.45,
+                0.5,
+                0.55,
+                0.6,
+                0.65,
+                0.7,
+                0.75
+            ],
+            "terrainYKeyThresholds": [
+                1,
+                1,
+                0.7,
+                0.5,
+                0.4,
+                0.3,
+                0.2,
+                0.1,
+                0
+            ]
         }
-      ]
-    },
-    {
-      "code": "flatlands",
-      "baseHeight": 0.2,
-      "noiseScale": 0.001,
-      "threshold": 0.5,
-      "weight": 6324,
-      "heightOffset": 0.65,
-      "genClimate": true,
-      "genRockStrata": true,
-      "genStructures": false,
-      "genVegetation": false,
-      "climate": {
-        "minRain": 0.2,
-        "maxRain": 0.8,
-        "minTemp": 0.1,
-        "maxTemp": 0.9
-      },
-      "rockStrata": {
-        "variant": "cliff",
-        "strata": [
-          { "rock": "granite", "thickness": 4 },
-          { "rock": "andesite", "thickness": 3 },
-          { "rock": "basalt", "thickness": 3 }
-        ]
-      },
-      "terrainOctaves":          [0, 0, 0.1, 0.15, 0.2, 0, 0.4, 0, 0],
-      "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.4, 0, 0],
-      "terrainYKeyPositions":    [0.000, 0.440, 0.460, 0.470],
-      "terrainYKeyThresholds":   [1.000, 1.000, 0.500, 0.000]
-    },
-    {
-      "code": "sheercliffs",
-      "baseHeight": 0.25,
-      "noiseScale": 0.0005,
-      "threshold": 0.95,
-      "weight": 1084,
-      "heightOffset": 0.55,
-      "genClimate": true,
-      "genRockStrata": true,
-      "genStructures": false,
-      "genVegetation": false,
-      "climate": {
-        "minRain": 0.2,
-        "maxRain": 0.8,
-        "minTemp": 0.1,
-        "maxTemp": 0.9
-      },
-      "rockStrata": {
-        "variant": "cliff",
-        "strata": [
-          { "rock": "granite", "thickness": 4 },
-          { "rock": "andesite", "thickness": 3 },
-          { "rock": "basalt", "thickness": 3 }
-        ]
-      },
-      "terrainOctaves":          [0.1, 0.2, 0.4, 0.6, 1.0, 0.6, 0.4, 0.3, 0.2],
-      "terrainOctaveThresholds": [0, 0, 0, 0, 0.3, 0, 0, 0, 0],
-      "terrainYKeyPositions":    [0.0, 0.35, 0.45, 0.46, 0.6, 0.7],
-      "terrainYKeyThresholds":   [1.0, 1.0, 0.5, 0.5, 0.2, 0.0]
-    },
-    {
-      "code": "towercliffs",
-      "baseHeight": 0.25,
-      "noiseScale": 0.0005,
-      "threshold": 0.97,
-      "weight": 723,
-      "heightOffset": 0.55,
-      "genClimate": true,
-      "genRockStrata": true,
-      "genStructures": false,
-      "genVegetation": false,
-      "climate": {
-        "minRain": 0.2,
-        "maxRain": 0.8,
-        "minTemp": 0.1,
-        "maxTemp": 0.9
-      },
-      "rockStrata": {
-        "variant": "cliff",
-        "strata": [
-          { "rock": "granite", "thickness": 4 },
-          { "rock": "andesite", "thickness": 3 },
-          { "rock": "basalt", "thickness": 3 }
-        ]
-      },
-      "terrainOctaves":          [0, 0, 0, 0, 0.2, 0.5, 1, 0.9, 0.4],
-      "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0.3],
-      "terrainYKeyPositions":    [0, 0.45, 0.48, 0.55, 0.63, 0.70, 0.75, 0.80, 0.86, 0.90],
-      "terrainYKeyThresholds":   [1, 1, 0.45, 0.30, 0.22, 0.20, 0.18, 0.15, 0.14, 0]
-    },
-    {
-      "code": "riceplateaus",
-      "baseHeight": 0.05,
-      "noiseScale": 0.00015,
-      "threshold": 0.4,
-      "weight": 7228,
-      "heightOffset": 0.65,
-      "genClimate": true,
-      "genRockStrata": true,
-      "genStructures": false,
-      "genVegetation": false,
-      "climate": {
-        "minRain": 0.2,
-        "maxRain": 0.8,
-        "minTemp": 0.1,
-        "maxTemp": 0.9
-      },
-      "rockStrata": {
-        "variant": "cliff",
-        "strata": [
-          { "rock": "granite", "thickness": 4 },
-          { "rock": "andesite", "thickness": 3 },
-          { "rock": "basalt", "thickness": 3 }
-        ]
-      },
-      "terrainOctaves":          [0, 0.1, 0.2, 0.35, 0.35, 0.2, 0.1],
-      "terrainOctaveThresholds": [0, 0, 0, 0.3, 0.3, 0, 0],
-      "terrainYKeyPositions":    [0.15, 0.35, 0.55, 0.75],
-      "terrainYKeyThresholds":   [1, 0.85, 0.6, 0]
-    }
-  ],
-  "replace": false
+    ],
+    "replace": false
 }

--- a/WorldgenMod/FixedCliffs/modinfo.json
+++ b/WorldgenMod/FixedCliffs/modinfo.json
@@ -4,7 +4,7 @@
   "name": "Fixed Cliffs Landforms",
   "version": "1.0.0",
   "authors": ["sapje16"],
-  "description": "Adds several custom landforms including flatlands, sheer cliffs, canyons, tower cliffs and rice plateaus.",
+  "description": "Adds custom landforms derived from vanilla terrain such as sinkhole plateaus, dry sea pillars, wide pillar cliffs, dry deep step mountains, land step mountains and terrace plateaus.",
   "dependencies": {
     "game": "1.20.12"
   }

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -54,18 +54,18 @@ Below is a minimal outline on how to structure and configure such a mod.
    {
      "replace": false,
      "landforms": {
-       "flatlands": { "weight": 100 },
-       "sheercliffs": { "weight": 250 },
-       "canyons": { "weight": 500 },
-       "towercliffs": { "weight": 50 },
-       "riceplateaus": { "weight": 1100 }
+       "sinkholeplateaus": { "weight": 2000 },
+       "dryseapillars": { "weight": 1500 },
+       "widepillarcliffs": { "weight": 1200 },
+       "drydeepstepmountains": { "weight": 1000 },
+       "landstepmountains": { "weight": 800 },
+       "terraceplateaus": { "weight": 2000 }
     }
   }
   ```
   (Vanilla landforms keep their existing weights, making about 15% of the total.)
 
-With these weights, the `riceplateaus` landform now exceeds half of all custom
-terrain generation, followed by `canyons` and `sheercliffs` in relative frequency.
+With these weights, `sinkholeplateaus` and `terraceplateaus` appear most often, while the pillar and mountain variants provide rarer dramatic terrain.
 
 5. **Allowing Structures to Spawn**
    - Patch `survival-worldgen-storystructures.json` so structures also target your new landforms.
@@ -79,18 +79,19 @@ terrain generation, followed by `canyons` and `sheercliffs` in relative frequenc
 ## Landform selection
 
 The landforms are mixed using the game's default worldgen, guided by the
-weights defined in `landformConfig.json` (for example, `riceplateaus` has the
+weights defined in `landformConfig.json` (for example, `terraceplateaus` has the
 highest weight). The `/tpl <name>` command from the TeleportLandform mod can
 teleport you to the nearest region to verify which landform is present.
 
 ## Planned Landforms
 The mod aims to implement the following terrain types:
 
-- **Flatlands** – large expanses of almost level ground.
-- **Sheer Cliffs** – abrupt vertical faces that rise sharply from surrounding areas.
-- **Canyons with narrow paths** – deep ravines bordered by tall cliffs.
-- **Tower Cliffs** – mostly flat areas punctuated by very tall, closely spaced pillars.
-- **Multi-level Plateaus** – terraced landscape with flat tops at varying heights, similar to oversized rice fields.
+- **Sinkhole Plateaus** – broad stepped depressions with flat tiers.
+- **Dry Sea Pillars** – pillar formations on land with wide paths between them.
+- **Wide Pillar Cliffs** – clustered cliffs featuring wide, walkable ledges.
+- **Dry Deep Step Mountains** – tall mountains with stacked steps but no water.
+- **Land Step Mountains** – smaller step mountains rising from plains.
+- **Terrace Plateaus** – numerous flat terraces forming high shelves.
 
 Each landform will generate separately. When a new world is created, approximately 85% of terrain should come from these new landforms and the remaining 15% from vanilla ones. Structures from the `story` set will be able to spawn on all new landforms if configured in `survival-worldgen-storystructures.json`.
 
@@ -120,14 +121,13 @@ preview instead.
 * **threshold** – minimum noise value required for the landform to generate at a
   given coordinate. Higher values make the feature rarer and more isolated.
 
-### Rice plateau layout
+### Terrace plateau layout
 
-`riceplateaus` now relies solely on vanilla landform parameters. Using
-`terrainOctaves` along with matching Y key arrays creates four broad terraces
-without any custom radius fields. A `baseHeight` of `0.05` and
-`heightOffset` of `0.65` place the top tier around 70 % of world height while a
-small `noiseScale` (`0.00015`) keeps the steps smooth. The updated octaves and
-Y keys approximate tiered shelves so no extra worldgen code is required.
+`terraceplateaus` is built solely from vanilla-style parameters. Arrays of
+`terrainOctaves` and Y keys create several smooth terraces without additional
+radius fields. A base height of `0.1` with `heightOffset` `0.65` places the top
+layer high above ground while a small `noiseScale` of `0.00015` keeps each step
+wide and flat.
 
 
 

--- a/WorldgenMod/terrain_generation_guide.md
+++ b/WorldgenMod/terrain_generation_guide.md
@@ -16,15 +16,15 @@ This document outlines the goals and technical steps required to improve terrain
 
 Focus landforms to adjust:
 
-- `sheercliffs` (main vertical cliff biome)
-- `towercliffs` (spires/towers)
-- `flatlands` (flat fill-in areas between dramatic terrain)
+- `sinkholeplateaus` (stepped depressions)
+- `dryseapillars` (pillar regions with open paths)
+- `widepillarcliffs` (cliff clusters with wide ledges)
 
 ---
 
 ## ⚖️ Config Adjustments
 
-### For `sheercliffs`:
+### For `widepillarcliffs`:
 
 **1. terrainYKeyThresholds and Positions** Replace with more plateau-friendly transitions:
 
@@ -33,7 +33,7 @@ Focus landforms to adjust:
 "terrainYKeyThresholds":   [1.0, 1.0, 0.5, 0.5, 0.2, 0.0]
 ```
 
-This creates: vertical cliff walls, flat shelves, and transition bands.
+This creates vertical cliff walls with broad shelves between them.
 
 **2. terrainOctaves** Sharpen terrain details:
 
@@ -89,13 +89,13 @@ Adjust weights in `landformConfig.json` to prioritize dramatic formations:
 
 ```json
 {
-  "code": "sheercliffs", "weight": 400
+  "code": "sinkholeplateaus", "weight": 2000
 },
 {
-  "code": "towercliffs", "weight": 300
+  "code": "dryseapillars", "weight": 1500
 },
 {
-  "code": "flatlands", "weight": 200
+  "code": "widepillarcliffs", "weight": 1200
 }
 ```
 
@@ -110,16 +110,16 @@ Adjust weights in `landformConfig.json` to prioritize dramatic formations:
 Example parameters:
 
 ```json
-"canyons": {
-  "noiseScale": 0.00025,
-  "terrainOctaves": [0.1, 0.2, 0.4, 0.6, 1, 0.8, 0.4],
-  "terrainYKeyPositions": [0.00, 0.25, 0.45, 0.65, 0.85, 0.95],
-  "terrainYKeyThresholds": [0, 0, 0.9, 1, 1, 1]
+"sinkholeplateaus": {
+  "noiseScale": 0.0003,
+  "terrainOctaves": [0, 0, 0, 0, 0, 1, 1, 1, 0],
+  "terrainYKeyPositions": [0.40, 0.50, 0.62, 0.65, 0.67],
+  "terrainYKeyThresholds": [1, 0.75, 0.6, 0.55, 0]
 },
-"riceplateaus": {
-  "heightOffset": 0.8,
-  "terrainYKeyPositions": [0.45, 0.65, 0.85, 1.05],
-  "terrainYKeyThresholds": [1, 1, 1, 0]
+"terraceplateaus": {
+  "heightOffset": 0.65,
+  "terrainYKeyPositions": [0.40, 0.55, 0.70, 0.75],
+  "terrainYKeyThresholds": [1, 0.5, 0.2, 0]
 }
 ```
 

--- a/perlin
+++ b/perlin
@@ -18,23 +18,25 @@ The `generate_noise_images.py` script reads these fields from a `landforms.json`
 
 ## Example Landforms
 
-From the README in `WorldgenMod`, five primary landforms are planned:
+From the README in `WorldgenMod`, six primary landforms are now used:
 
-- **Flatlands** – nearly level terrain.
-- **Sheer Cliffs** – tall vertical faces.
-- **Canyons** – deep ravines with narrow paths.
-- **Tower Cliffs** – isolated pillars rising from flat surroundings.
-- **Multi-level Plateaus** (`riceplateaus`) – tiered shelves at several heights.
+- **Sinkhole Plateaus** – stepped depressions with wide flat floors.
+- **Dry Sea Pillars** – tall pillars surrounded by walkable ground.
+- **Wide Pillar Cliffs** – cliff clusters offering broad ledges.
+- **Dry Deep Step Mountains** – massive stepped peaks without water.
+- **Land Step Mountains** – smaller step mountains on land.
+- **Terrace Plateaus** – many stacked terraces creating flat shelves.
 
 The table below lists representative parameter choices from `FixedCliffs/landforms.json` that influence these shapes.
 
-| Code           | noiseScale | threshold | Example notes |
-|---------------|-----------|----------|---------------|
-| `flatlands`    | `0.001`   | `0.5`    | Gentle height changes. Terrain octaves emphasize smooth slopes.
-| `sheercliffs`  | `0.0005`  | `0.95`   | High threshold and strong octaves create abrupt walls.
-| `canyons`      | `0.0005`  | `0.2`    | Tall plateaus with narrow low paths.
-| `towercliffs`  | `0.0005`  | `0.97`   | Multiple octaves focus noise near the top to form pillars.
-| `riceplateaus` | `0.0002`  | `0.4`    | Wide terraces forming large flat platforms.
+| Code                | noiseScale | threshold | Example notes |
+|--------------------|-----------|----------|---------------|
+| `sinkholeplateaus` | `0.0003`  | `0.3`    | Broad depressions with stepped floors.
+| `dryseapillars`    | `0.0004`  | `0.6`    | Land-based pillars with paths between.
+| `widepillarcliffs` | `0.00035` | `0.65`   | Cliffs with wide ledges and pillars.
+| `drydeepstepmountains` | `0.00025` | `0.4` | Large stepped mountains.
+| `landstepmountains`| `0.00025` | `0.5`    | Smaller step mountains above plains.
+| `terraceplateaus`  | `0.00015` | `0.45`   | Repeating high terraces.
 
 Adjusting these values changes how often a landform appears and how dramatic its features look. Lower the threshold to spread a shape farther across the world. Increase specific octave amplitudes to add jagged details at different sizes.
 


### PR DESCRIPTION
## Summary
- overhaul FixedCliffs landforms with variants of vanilla terrain
- update JSON patches for landforms, weights and structures
- regenerate docs to explain new landforms and noise parameters
- refresh Perlin reference table

## Testing
- `python3 WorldgenMod/generate_noise_images.py --size 64 --seed 1 --zoom 2`


------
https://chatgpt.com/codex/tasks/task_b_6857e893c5f08323b5fa063c4cfd6269