### PR TITLE
Flatter landforms

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/patches/worldgen/landforms.json
@@ -1,488 +1,488 @@
 [
-    {
-        "op": "add",
-        "path": "/variants/-",
-        "value": {
-            "code": "sinkholeplateaus",
-            "baseHeight": 0.2,
-            "noiseScale": 0.0003,
-            "threshold": 0.3,
-            "weight": 2000,
-            "heightOffset": 0.7,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                1,
-                1,
-                1,
-                0
-            ],
-            "terrainOctaveThresholds": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-            ],
-            "terrainYKeyPositions": [
-                0.4,
-                0.42,
-                0.46,
-                0.5,
-                0.54,
-                0.58,
-                0.62,
-                0.65,
-                0.67
-            ],
-            "terrainYKeyThresholds": [
-                1.0,
-                0.9,
-                0.85,
-                0.75,
-                0.7,
-                0.65,
-                0.6,
-                0.55,
-                0
-            ]
-        },
-        "file": "game:worldgen/landforms.json",
-        "side": "Server"
+  {
+    "op": "add",
+    "path": "/variants/-",
+    "value": {
+      "code": "sinkholeplateaus",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.3,
+      "weight": 2000,
+      "heightOffset": 0.4,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.4,
+        0.42,
+        0.46,
+        0.5,
+        0.54,
+        0.58,
+        0.62,
+        0.65,
+        0.67
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.9,
+        0.85,
+        0.75,
+        0.7,
+        0.65,
+        0.6,
+        0.55,
+        0
+      ]
     },
-    {
-        "op": "add",
-        "path": "/variants/-",
-        "value": {
-            "code": "dryseapillars",
-            "baseHeight": 0.25,
-            "noiseScale": 0.0004,
-            "threshold": 0.6,
-            "weight": 1500,
-            "heightOffset": 0.75,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0,
-                0,
-                0,
-                0.2,
-                0.6,
-                1,
-                0.7,
-                0.3
-            ],
-            "terrainOctaveThresholds": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0.15
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.37,
-                0.44,
-                0.52,
-                0.6,
-                0.7,
-                0.82,
-                0.88,
-                0.95
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                1,
-                0.5,
-                0.3,
-                0.25,
-                0.2,
-                0.15,
-                0.1,
-                0
-            ]
-        },
-        "file": "game:worldgen/landforms.json",
-        "side": "Server"
+    "file": "game:worldgen/landforms.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/variants/-",
+    "value": {
+      "code": "dryseapillars",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.6,
+      "weight": 1500,
+      "heightOffset": 0.4,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.6,
+        1,
+        0.7,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.15
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.37,
+        0.44,
+        0.52,
+        0.6,
+        0.7,
+        0.82,
+        0.88,
+        0.95
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.5,
+        0.3,
+        0.25,
+        0.2,
+        0.15,
+        0.1,
+        0
+      ]
     },
-    {
-        "op": "add",
-        "path": "/variants/-",
-        "value": {
-            "code": "widepillarcliffs",
-            "baseHeight": 0.25,
-            "noiseScale": 0.00035,
-            "threshold": 0.65,
-            "weight": 1200,
-            "heightOffset": 0.6,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0,
-                0,
-                0.1,
-                0.3,
-                0.5,
-                1,
-                0.8,
-                0.3
-            ],
-            "terrainOctaveThresholds": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0.3
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.48,
-                0.53,
-                0.58,
-                0.63,
-                0.7,
-                0.78,
-                0.84,
-                0.9,
-                0.96
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                1,
-                0.45,
-                0.38,
-                0.35,
-                0.3,
-                0.25,
-                0.18,
-                0.15,
-                0
-            ]
-        },
-        "file": "game:worldgen/landforms.json",
-        "side": "Server"
+    "file": "game:worldgen/landforms.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/variants/-",
+    "value": {
+      "code": "widepillarcliffs",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.65,
+      "weight": 1200,
+      "heightOffset": 0.4,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.1,
+        0.3,
+        0.5,
+        1,
+        0.8,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.48,
+        0.53,
+        0.58,
+        0.63,
+        0.7,
+        0.78,
+        0.84,
+        0.9,
+        0.96
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.45,
+        0.38,
+        0.35,
+        0.3,
+        0.25,
+        0.18,
+        0.15,
+        0
+      ]
     },
-    {
-        "op": "add",
-        "path": "/variants/-",
-        "value": {
-            "code": "drydeepstepmountains",
-            "baseHeight": 0.25,
-            "noiseScale": 0.00025,
-            "threshold": 0.4,
-            "weight": 1000,
-            "heightOffset": 0.8,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0.81,
-                0.729,
-                0.6561,
-                0.59049,
-                0.531441,
-                0.4,
-                0.2,
-                0
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.45,
-                0.55,
-                0.62,
-                0.7,
-                0.78,
-                0.86
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                0.7,
-                0.5,
-                0.35,
-                0.25,
-                0.1,
-                0
-            ]
-        },
-        "file": "game:worldgen/landforms.json",
-        "side": "Server"
+    "file": "game:worldgen/landforms.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/variants/-",
+    "value": {
+      "code": "drydeepstepmountains",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.4,
+      "weight": 1000,
+      "heightOffset": 0.45,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.45,
+        0.55,
+        0.62,
+        0.7,
+        0.78,
+        0.86
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.7,
+        0.5,
+        0.35,
+        0.25,
+        0.1,
+        0
+      ]
     },
-    {
-        "op": "add",
-        "path": "/variants/-",
-        "value": {
-            "code": "landstepmountains",
-            "baseHeight": 0.25,
-            "noiseScale": 0.00025,
-            "threshold": 0.5,
-            "weight": 800,
-            "heightOffset": 0.8,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0.81,
-                0.729,
-                0.6561,
-                0,
-                0.531441,
-                0.4,
-                0.2,
-                0
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.43,
-                0.53,
-                0.6,
-                0.7,
-                0.78,
-                0.86,
-                0.92,
-                0.97
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                1,
-                0.5,
-                0.4,
-                0.3,
-                0.2,
-                0.15,
-                0.1,
-                0
-            ]
-        },
-        "file": "game:worldgen/landforms.json",
-        "side": "Server"
+    "file": "game:worldgen/landforms.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/variants/-",
+    "value": {
+      "code": "landstepmountains",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.5,
+      "weight": 800,
+      "heightOffset": 0.45,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.43,
+        0.53,
+        0.6,
+        0.7,
+        0.78,
+        0.86,
+        0.92,
+        0.97
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.5,
+        0.4,
+        0.3,
+        0.2,
+        0.15,
+        0.1,
+        0
+      ]
     },
-    {
-        "op": "add",
-        "path": "/variants/-",
-        "value": {
-            "code": "terraceplateaus",
-            "baseHeight": 0.1,
-            "noiseScale": 0.00015,
-            "threshold": 0.45,
-            "weight": 2000,
-            "heightOffset": 0.65,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0,
-                0,
-                0.25,
-                0.3,
-                1,
-                1,
-                0.7,
-                0.15
-            ],
-            "terrainOctaveThresholds": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.4,
-                0.45,
-                0.5,
-                0.55,
-                0.6,
-                0.65,
-                0.7,
-                0.75
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                1,
-                0.7,
-                0.5,
-                0.4,
-                0.3,
-                0.2,
-                0.1,
-                0
-            ]
-        },
-        "file": "game:worldgen/landforms.json",
-        "side": "Server"
-    }
+    "file": "game:worldgen/landforms.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/variants/-",
+    "value": {
+      "code": "terraceplateaus",
+      "baseHeight": 0.05,
+      "noiseScale": 0.0001,
+      "threshold": 0.45,
+      "weight": 2000,
+      "heightOffset": 0.25,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.25,
+        0.3,
+        1,
+        1,
+        0.7,
+        0.15
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.4,
+        0.45,
+        0.5,
+        0.55,
+        0.6,
+        0.65,
+        0.7,
+        0.75
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.7,
+        0.5,
+        0.4,
+        0.3,
+        0.2,
+        0.1,
+        0
+      ]
+    },
+    "file": "game:worldgen/landforms.json",
+    "side": "Server"
+  }
 ]

--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -1,456 +1,456 @@
 {
-    "code": "landforms",
-    "variants": [
-        {
-            "code": "sinkholeplateaus",
-            "baseHeight": 0.2,
-            "noiseScale": 0.0003,
-            "threshold": 0.3,
-            "weight": 2000,
-            "heightOffset": 0.7,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                1,
-                1,
-                1,
-                0
-            ],
-            "terrainOctaveThresholds": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-            ],
-            "terrainYKeyPositions": [
-                0.4,
-                0.42,
-                0.46,
-                0.5,
-                0.54,
-                0.58,
-                0.62,
-                0.65,
-                0.67
-            ],
-            "terrainYKeyThresholds": [
-                1.0,
-                0.9,
-                0.85,
-                0.75,
-                0.7,
-                0.65,
-                0.6,
-                0.55,
-                0
-            ]
-        },
-        {
-            "code": "dryseapillars",
-            "baseHeight": 0.25,
-            "noiseScale": 0.0004,
-            "threshold": 0.6,
-            "weight": 1500,
-            "heightOffset": 0.75,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0,
-                0,
-                0,
-                0.2,
-                0.6,
-                1,
-                0.7,
-                0.3
-            ],
-            "terrainOctaveThresholds": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0.15
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.37,
-                0.44,
-                0.52,
-                0.6,
-                0.7,
-                0.82,
-                0.88,
-                0.95
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                1,
-                0.5,
-                0.3,
-                0.25,
-                0.2,
-                0.15,
-                0.1,
-                0
-            ]
-        },
-        {
-            "code": "widepillarcliffs",
-            "baseHeight": 0.25,
-            "noiseScale": 0.00035,
-            "threshold": 0.65,
-            "weight": 1200,
-            "heightOffset": 0.6,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0,
-                0,
-                0.1,
-                0.3,
-                0.5,
-                1,
-                0.8,
-                0.3
-            ],
-            "terrainOctaveThresholds": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0.3
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.48,
-                0.53,
-                0.58,
-                0.63,
-                0.7,
-                0.78,
-                0.84,
-                0.9,
-                0.96
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                1,
-                0.45,
-                0.38,
-                0.35,
-                0.3,
-                0.25,
-                0.18,
-                0.15,
-                0
-            ]
-        },
-        {
-            "code": "drydeepstepmountains",
-            "baseHeight": 0.25,
-            "noiseScale": 0.00025,
-            "threshold": 0.4,
-            "weight": 1000,
-            "heightOffset": 0.8,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0.81,
-                0.729,
-                0.6561,
-                0.59049,
-                0.531441,
-                0.4,
-                0.2,
-                0
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.45,
-                0.55,
-                0.62,
-                0.7,
-                0.78,
-                0.86
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                0.7,
-                0.5,
-                0.35,
-                0.25,
-                0.1,
-                0
-            ]
-        },
-        {
-            "code": "landstepmountains",
-            "baseHeight": 0.25,
-            "noiseScale": 0.00025,
-            "threshold": 0.5,
-            "weight": 800,
-            "heightOffset": 0.8,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0.81,
-                0.729,
-                0.6561,
-                0,
-                0.531441,
-                0.4,
-                0.2,
-                0
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.43,
-                0.53,
-                0.6,
-                0.7,
-                0.78,
-                0.86,
-                0.92,
-                0.97
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                1,
-                0.5,
-                0.4,
-                0.3,
-                0.2,
-                0.15,
-                0.1,
-                0
-            ]
-        },
-        {
-            "code": "terraceplateaus",
-            "baseHeight": 0.1,
-            "noiseScale": 0.00015,
-            "threshold": 0.45,
-            "weight": 2000,
-            "heightOffset": 0.65,
-            "genClimate": true,
-            "genRockStrata": true,
-            "genStructures": false,
-            "genVegetation": false,
-            "climate": {
-                "minRain": 0.2,
-                "maxRain": 0.8,
-                "minTemp": 0.1,
-                "maxTemp": 0.9
-            },
-            "rockStrata": {
-                "variant": "cliff",
-                "strata": [
-                    {
-                        "rock": "granite",
-                        "thickness": 4
-                    },
-                    {
-                        "rock": "andesite",
-                        "thickness": 3
-                    },
-                    {
-                        "rock": "basalt",
-                        "thickness": 3
-                    }
-                ]
-            },
-            "terrainOctaves": [
-                0,
-                0,
-                0,
-                0.25,
-                0.3,
-                1,
-                1,
-                0.7,
-                0.15
-            ],
-            "terrainOctaveThresholds": [
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0,
-                0
-            ],
-            "terrainYKeyPositions": [
-                0.0,
-                0.4,
-                0.45,
-                0.5,
-                0.55,
-                0.6,
-                0.65,
-                0.7,
-                0.75
-            ],
-            "terrainYKeyThresholds": [
-                1,
-                1,
-                0.7,
-                0.5,
-                0.4,
-                0.3,
-                0.2,
-                0.1,
-                0
-            ]
-        }
-    ],
-    "replace": false
+  "code": "landforms",
+  "variants": [
+    {
+      "code": "sinkholeplateaus",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.3,
+      "weight": 2000,
+      "heightOffset": 0.4,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.4,
+        0.42,
+        0.46,
+        0.5,
+        0.54,
+        0.58,
+        0.62,
+        0.65,
+        0.67
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.9,
+        0.85,
+        0.75,
+        0.7,
+        0.65,
+        0.6,
+        0.55,
+        0
+      ]
+    },
+    {
+      "code": "dryseapillars",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.6,
+      "weight": 1500,
+      "heightOffset": 0.4,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.6,
+        1,
+        0.7,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.15
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.37,
+        0.44,
+        0.52,
+        0.6,
+        0.7,
+        0.82,
+        0.88,
+        0.95
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.5,
+        0.3,
+        0.25,
+        0.2,
+        0.15,
+        0.1,
+        0
+      ]
+    },
+    {
+      "code": "widepillarcliffs",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.65,
+      "weight": 1200,
+      "heightOffset": 0.4,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.1,
+        0.3,
+        0.5,
+        1,
+        0.8,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.48,
+        0.53,
+        0.58,
+        0.63,
+        0.7,
+        0.78,
+        0.84,
+        0.9,
+        0.96
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.45,
+        0.38,
+        0.35,
+        0.3,
+        0.25,
+        0.18,
+        0.15,
+        0
+      ]
+    },
+    {
+      "code": "drydeepstepmountains",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.4,
+      "weight": 1000,
+      "heightOffset": 0.45,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.45,
+        0.55,
+        0.62,
+        0.7,
+        0.78,
+        0.86
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.7,
+        0.5,
+        0.35,
+        0.25,
+        0.1,
+        0
+      ]
+    },
+    {
+      "code": "landstepmountains",
+      "baseHeight": 0.1,
+      "noiseScale": 0.00012,
+      "threshold": 0.5,
+      "weight": 800,
+      "heightOffset": 0.45,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.43,
+        0.53,
+        0.6,
+        0.7,
+        0.78,
+        0.86,
+        0.92,
+        0.97
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.5,
+        0.4,
+        0.3,
+        0.2,
+        0.15,
+        0.1,
+        0
+      ]
+    },
+    {
+      "code": "terraceplateaus",
+      "baseHeight": 0.05,
+      "noiseScale": 0.0001,
+      "threshold": 0.45,
+      "weight": 2000,
+      "heightOffset": 0.25,
+      "genClimate": true,
+      "genRockStrata": true,
+      "genStructures": false,
+      "genVegetation": false,
+      "climate": {
+        "minRain": 0.2,
+        "maxRain": 0.8,
+        "minTemp": 0.1,
+        "maxTemp": 0.9
+      },
+      "rockStrata": {
+        "variant": "cliff",
+        "strata": [
+          {
+            "rock": "granite",
+            "thickness": 4
+          },
+          {
+            "rock": "andesite",
+            "thickness": 3
+          },
+          {
+            "rock": "basalt",
+            "thickness": 3
+          }
+        ]
+      },
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.25,
+        0.3,
+        1,
+        1,
+        0.7,
+        0.15
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.4,
+        0.45,
+        0.5,
+        0.55,
+        0.6,
+        0.65,
+        0.7,
+        0.75
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.7,
+        0.5,
+        0.4,
+        0.3,
+        0.2,
+        0.1,
+        0
+      ]
+    }
+  ],
+  "replace": false
 }


### PR DESCRIPTION
## Summary
- tweak landform parameters in `landforms.json` to use smaller noiseScale, baseHeight, and heightOffset for wider and flatter terrain
- apply the same values to the game patch

## Testing
- `./setup_env.sh`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6857efb9d6808323ae67407f0614dd0a