### PR TITLE
Flatten terrace plateaus

### DIFF
--- a/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
+++ b/WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json
@@ -359,7 +359,7 @@
     {
       "code": "terraceplateaus",
       "baseHeight": 0.1,
-      "noiseScale": 0.00015,
+      "noiseScale": 0.00005,
       "threshold": 0.45,
       "weight": 2000,
       "heightOffset": 0.65,
@@ -394,12 +394,12 @@
         0,
         0,
         0,
-        0.25,
+        0.1,
+        0.2,
+        0.6,
         0.3,
-        1,
-        1,
-        0.7,
-        0.15
+        0.2,
+        0.1
       ],
       "terrainOctaveThresholds": [
         0,
@@ -413,15 +413,15 @@
         0
       ],
       "terrainYKeyPositions": [
-        0.40,
-        0.55,
-        0.70,
-        0.75
+        0.35,
+        0.65,
+        0.90,
+        0.95
       ],
       "terrainYKeyThresholds": [
         1,
-        0.5,
-        0.2,
+        0.4,
+        0.1,
         0
       ]
     }

--- a/WorldgenMod/readme
+++ b/WorldgenMod/readme
@@ -126,8 +126,8 @@ preview instead.
 `terraceplateaus` is built solely from vanilla-style parameters. Arrays of
 `terrainOctaves` and Y keys create several smooth terraces without additional
 radius fields. A base height of `0.1` with `heightOffset` `0.65` places the top
-layer high above ground while a small `noiseScale` of `0.00015` keeps each step
-wide and flat.
+layer high above ground while a very small `noiseScale` of `0.00005` now keeps
+each step much wider and flatter.
 
 
 


### PR DESCRIPTION
## Summary
- reduce noise scale for `terraceplateaus` so terrain spans a wider area
- smooth out higher frequencies for flatter steps
- update the README to document the new small scale

## Testing
- `pip install -r requirements.txt`
- `python3 WorldgenMod/generate_noise_images.py --landforms-file WorldgenMod/FixedCliffs/assets/fixedcliffs/worldgen/landforms.json --size 32 --seed 1`


------
https://chatgpt.com/codex/tasks/task_b_6857f5ec2ad883239b48a5ab9f63bea8