### PR TITLE
Add SelectedLandforms worldgen mod

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -1,0 +1,4 @@
+{
+    "code": "landforms",
+    "variants": []
+}

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -1,0 +1,70 @@
+[
+  {
+    "op": "addmerge",
+    "path": "/variants",
+    "value": [
+      {
+        "code": "p&vflat lowlands",
+        "comment": "Very large scale low land flat lands",
+        "hexcolor": "#79E02E",
+        "weight": 145,
+        "terrainOctaves": [0.1, 0.1, 1, 1, 0.1, 0.1, 0.1, 0.1, 0.05],
+        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.03, 0.03, 0.05],
+        "terrainYKeyPositions": [0.430, 0.500, 0.518, 0.567, 0.600],
+        "terrainYKeyThresholds": [1.000, 0.712, 0.699, 0.371, 0.000]
+      },
+      {
+        "code": "p&vflat midlands",
+        "comment": "Very large scale mid land flat lands",
+        "hexcolor": "#79E02E",
+        "weight": 130,
+        "terrainOctaves": [0.1, 0.1, 1, 1, 0.1, 0.1, 0.1, 0.1, 0.05],
+        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.03, 0.03, 0.05],
+        "terrainYKeyPositions": [0.450, 0.532, 0.558, 0.610, 0.700],
+        "terrainYKeyThresholds": [1.000, 0.701, 0.562, 0.457, 0.000]
+      },
+      {
+        "code": "p&vflat highlands",
+        "comment": "Very large scale high land flat lands",
+        "hexcolor": "#79E02E",
+        "weight": 115,
+        "terrainOctaves": [0.1, 0.1, 1, 1, 1, 0.1, 0.1, 0.1, 0.09],
+        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.03, 0.03, 0.05],
+        "terrainYKeyPositions": [0.5, 0.517, 0.529, 0.550, 0.604, 0.660, 0.691, 0.717, 0.767],
+        "terrainYKeyThresholds": [1.000, 0.829, 0.776, 0.720, 0.622, 0.512, 0.404, 0.227, 0.000]
+      },
+      {
+        "code": "p&vRealistic mountains",
+        "comment": "Very large scale mountains",
+        "hexcolor": "#84A878",
+        "weight": 140,
+        "terrainOctaves": [0.1, 0.1, 1, 0.5, 0.5, 0.1, 0.1, 0.1, 0.1, 0.05],
+        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0.03, 0.03, 0.05],
+        "terrainYKeyPositions": [0.450, 0.535, 0.630, 0.805, 0.963, 1.000],
+        "terrainYKeyThresholds": [1.000, 0.596, 0.304, 0.160, 0.045, 0.000]
+      },
+      {
+        "code": "p&vsteppedsinkholes",
+        "comment": "Stepped sink holes",
+        "hexcolor": "#AAAA00",
+        "weight": 1.5,
+        "terrainOctaves": [0.1, 0.1, 0, 0, 0, 1, 1, 1, 0],
+        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "terrainYKeyPositions": [0.431, 0.436, 0.457, 0.462, 0.484, 0.489, 0.513, 0.518, 0.525],
+        "terrainYKeyThresholds": [0.999, 0.814, 0.816, 0.761, 0.760, 0.719, 0.718, 0.688, 0.000],
+        "mutations": [
+          {
+            "code": "p&vsteppedsinkhold-cavemut",
+            "comment": "Cave mutation",
+            "chance": 0.05,
+            "hexcolor": "#AAAA00",
+            "terrainYKeyPositions": [0.399, 0.419, 0.427, 0.437, 0.457, 0.462, 0.484, 0.489, 0.513, 0.518, 0.525],
+            "terrainYKeyThresholds": [1.000, 0.816, 0.035, 0.808, 0.816, 0.761, 0.760, 0.719, 0.718, 0.688, 0.000]
+          }
+        ]
+      }
+    ],
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  }
+]

--- a/WorldgenMod/SelectedLandforms/modinfo.json
+++ b/WorldgenMod/SelectedLandforms/modinfo.json
@@ -1,0 +1,11 @@
+{
+  "type": "content",
+  "modid": "selectedlandforms",
+  "name": "Selected Landforms",
+  "description": "Worldgen with a curated subset of plains and valleys landforms.",
+  "version": "0.1.0",
+  "authors": ["Unknown"],
+  "dependencies": {
+    "game": "1.20.12"
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `SelectedLandforms` mod
- remove all vanilla landforms via an empty override
- add a patch that injects a curated subset of landforms from Plains & Valleys

## Testing
- `./setup_env.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_687cc2dd797483239946697fa993ae18