### PR TITLE
Reduce weight of non-selected landforms

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landformWeights.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landformWeights.json
@@ -1,0 +1,261 @@
+[
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vcold glaciers']/weight",
+    "value": 12.0,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vcold mountain range']/weight",
+    "value": 11.0,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vwetlands']/weight",
+    "value": 1.2,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vcoastal flatlands']/weight",
+    "value": 1.6,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vRealistic mountains']/weight",
+    "value": 1.4,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vhillplateu']/weight",
+    "value": 0.16,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vlargelake']/weight",
+    "value": 1.12,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vlargeislands']/weight",
+    "value": 0.13,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vrealisticmountains-ledged']/weight",
+    "value": 0.15,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vrealisticmountains-quintupleledged']/weight",
+    "value": 0.012,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vflatmarsh']/weight",
+    "value": 0.14,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vshallowmillionstepmountains']/weight",
+    "value": 0.015,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vmediummillionstepmountains']/weight",
+    "value": 0.015,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vtallmillionstepmountains']/weight",
+    "value": 0.015,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vsiberiansinkholes']/weight",
+    "value": 0.11,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vshallowislands']/weight",
+    "value": 0.11,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vsinglestep near-sea level flat grasslands']/weight",
+    "value": 0.11,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vrollinghills']/weight",
+    "value": 0.11,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vlowrollinghills']/weight",
+    "value": 0.11,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vsmallshallowislands']/weight",
+    "value": 0.11,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vneedledflatlands']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vcliffy rolling hills']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vcliffislands']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vcliffislands']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vbumplands']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vroundclifflandshilly']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vsparsecliffyswamplands']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vdensecliffyswamplands']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vroughflatlands']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vcliffislands']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vflathillvalley']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vsmallsealevelplateus']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vmediumseapillars']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vmediumlandpillars']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vmarsh']/weight",
+    "value": 0.11,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vbumpy marsh']/weight",
+    "value": 0.015,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vdeathmarsh']/weight",
+    "value": 0.011,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  }
+]

--- a/WorldgenMod/SelectedLandforms/modinfo.json
+++ b/WorldgenMod/SelectedLandforms/modinfo.json
@@ -3,7 +3,7 @@
   "modid": "selectedlandforms",
   "name": "Selected Landforms",
   "description": "Worldgen with a curated subset of plains and valleys landforms.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "authors": ["Unknown"],
   "dependencies": {
     "game": "1.20.12"


### PR DESCRIPTION
## Summary
- lower remaining landform weights so they only appear one percent as often
- bump SelectedLandforms mod version to 0.2.0

## Testing
- `./setup_env.sh`

------
https://chatgpt.com/codex/tasks/task_b_687cce2a6d6083239cbbb1fc56eaa5a7