### PR TITLE
Prioritize stepped sinkhole landform

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -37,7 +37,7 @@
         "code": "p&vsteppedsinkholes",
         "comment": "Stepped sink holes",
         "hexcolor": "#AAAA00",
-        "weight": 1.5,
+        "weight": 8000,
         "terrainOctaves": [0.1, 0.1, 0, 0, 0, 1, 1, 1, 0],
         "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
         "terrainYKeyPositions": [0.431, 0.436, 0.457, 0.462, 0.484, 0.489, 0.513, 0.518, 0.525],
@@ -52,6 +52,30 @@
             "terrainYKeyThresholds": [1.000, 0.816, 0.035, 0.808, 0.816, 0.761, 0.760, 0.719, 0.718, 0.688, 0.000]
           }
         ]
+      },
+      {
+        "code": "p&vsteppedsinkholes-large",
+        "comment": "Large stepped sink holes",
+        "hexcolor": "#CCAA00",
+        "weight": 8000,
+        "noiseScale": 0.0002,
+        "terrainOctaves": [0.1, 0.1, 0, 0, 0, 1, 1, 1, 0],
+        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "terrainYKeyPositions": [0.40, 0.44, 0.48, 0.52, 0.56, 0.60],
+        "terrainYKeyThresholds": [1.0, 0.86, 0.82, 0.78, 0.74, 0.0],
+        "plateauCount": 3
+      },
+      {
+        "code": "p&vsteppedsinkholes-mega",
+        "comment": "Huge multi-tiered sink holes",
+        "hexcolor": "#DDCC00",
+        "weight": 8000,
+        "noiseScale": 0.00015,
+        "terrainOctaves": [0.1, 0.1, 0, 0, 0, 1, 1, 1, 0],
+        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "terrainYKeyPositions": [0.38, 0.42, 0.46, 0.50, 0.55, 0.60, 0.65],
+        "terrainYKeyThresholds": [1.0, 0.86, 0.82, 0.78, 0.74, 0.70, 0.0],
+        "plateauCount": 4
       }
     ],
     "file": "game:worldgen/landforms.json",

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/worldgen/landformConfig.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/worldgen/landformConfig.json
@@ -1,0 +1,23 @@
+[
+  {
+    "op": "add",
+    "path": "/landforms/p&vsteppedsinkholes",
+    "value": {"weight": 8000},
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/landforms/p&vsteppedsinkholes-large",
+    "value": {"weight": 8000},
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/landforms/p&vsteppedsinkholes-mega",
+    "value": {"weight": 8000},
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server"
+  }
+]

--- a/WorldgenMod/SelectedLandforms/modinfo.json
+++ b/WorldgenMod/SelectedLandforms/modinfo.json
@@ -2,9 +2,9 @@
   "type": "content",
   "modid": "selectedlandforms",
   "name": "Selected Landforms",
-  "description": "Worldgen with a curated subset of plains and valleys landforms.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "authors": ["Unknown"],
+  "description": "Worldgen focusing almost entirely on stepped sinkhole landforms with larger multi-tier variants.",
   "dependencies": {
     "game": "1.20.12"
   }


### PR DESCRIPTION
## Summary
- update SelectedLandforms modinfo and increase version
- massively increase the weight of `p&vsteppedsinkholes`
- add large and mega stepped sinkhole variants
- patch worldgen config so stepped sinkholes dominate map generation

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687cd2b891848323a71efd24b1f9c2bf