### PR TITLE
Adjust sinkhole shape parameters

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -65,9 +65,9 @@
         "terrainYKeyThresholds": [1.0, 0.90, 0.86, 0.82, 0.80, 0.0],
         "plateauCount": 5,
         "baseRadius": 400,
-        "radiusStep": 0.90,
-        "radiusNoiseScale": 0.25,
-        "radiusNoiseAmplitude": 0.4
+        "radiusStep": 0.95,
+        "radiusNoiseScale": 0.15,
+        "radiusNoiseAmplitude": 0.2
       },
       {
         "code": "p&vsteppedsinkholes-mega",
@@ -81,9 +81,9 @@
         "terrainYKeyThresholds": [1.0, 0.92, 0.88, 0.84, 0.80, 0.76, 0.0],
         "plateauCount": 6,
         "baseRadius": 600,
-        "radiusStep": 0.92,
-        "radiusNoiseScale": 0.25,
-        "radiusNoiseAmplitude": 0.35
+        "radiusStep": 0.96,
+        "radiusNoiseScale": 0.15,
+        "radiusNoiseAmplitude": 0.2
       }
     ],
     "file": "game:worldgen/landforms.json",

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -99,8 +99,8 @@ def sample_height(params, x, z):
         step_factor = 0.0
         for cx in range(base_cell_x - 1, base_cell_x + 2):
             for cz in range(base_cell_z - 1, base_cell_z + 2):
-                jitter_x = warp_noise_x.noise2(cx * 0.1, cz * 0.1) * cell_size * 0.4
-                jitter_z = warp_noise_z.noise2(cx * 0.1 + 1000, cz * 0.1 + 1000) * cell_size * 0.4
+                jitter_x = warp_noise_x.noise2(cx * 0.1, cz * 0.1) * cell_size * 0.2
+                jitter_z = warp_noise_z.noise2(cx * 0.1 + 1000, cz * 0.1 + 1000) * cell_size * 0.2
                 center_x = (cx + 0.5) * cell_size + jitter_x
                 center_z = (cz + 0.5) * cell_size + jitter_z
                 dx = x - center_x


### PR DESCRIPTION
## Summary
- tweak sinkhole radius settings for rounder features
- reduce jitter in noise preview script

## Testing
- `pip install -r requirements.txt`
- `python WorldgenMod/generate_noise_images.py --size 32 --seed 1 --cross-section --zoom 0.5` *(fails: AttributeError: 'list' object has no attribute 'get')*

------
https://chatgpt.com/codex/tasks/task_b_687ce391157c83238147d649bde927e8