### PR TITLE
Update landform weights for sinkholes and cliffs

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landformWeights.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landformWeights.json
@@ -8,6 +8,34 @@
   },
   {
     "op": "replace",
+    "path": "/variants/*[code='p&vsteppedsinkholes']/weight",
+    "value": 40.0,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vflat lowlands']/weight",
+    "value": 5.0,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vflat midlands']/weight",
+    "value": 5.0,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
+    "path": "/variants/*[code='p&vflat highlands']/weight",
+    "value": 5.0,
+    "file": "game:worldgen/landforms.json",
+    "side": "server"
+  },
+  {
+    "op": "replace",
     "path": "/variants/*[code='p&vcold mountain range']/weight",
     "value": 11.0,
     "file": "game:worldgen/landforms.json",
@@ -156,14 +184,7 @@
   {
     "op": "replace",
     "path": "/variants/*[code='p&vcliffislands']/weight",
-    "value": 0.011,
-    "file": "game:worldgen/landforms.json",
-    "side": "server"
-  },
-  {
-    "op": "replace",
-    "path": "/variants/*[code='p&vcliffislands']/weight",
-    "value": 0.011,
+    "value": 44.0,
     "file": "game:worldgen/landforms.json",
     "side": "server"
   },
@@ -198,13 +219,6 @@
   {
     "op": "replace",
     "path": "/variants/*[code='p&vroughflatlands']/weight",
-    "value": 0.011,
-    "file": "game:worldgen/landforms.json",
-    "side": "server"
-  },
-  {
-    "op": "replace",
-    "path": "/variants/*[code='p&vcliffislands']/weight",
     "value": 0.011,
     "file": "game:worldgen/landforms.json",
     "side": "server"

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -7,7 +7,7 @@
         "code": "p&vflat lowlands",
         "comment": "Very large scale low land flat lands",
         "hexcolor": "#79E02E",
-        "weight": 145,
+        "weight": 5,
         "terrainOctaves": [0.1, 0.1, 1, 1, 0.1, 0.1, 0.1, 0.1, 0.05],
         "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.03, 0.03, 0.05],
         "terrainYKeyPositions": [0.430, 0.500, 0.518, 0.567, 0.600],
@@ -17,7 +17,7 @@
         "code": "p&vflat midlands",
         "comment": "Very large scale mid land flat lands",
         "hexcolor": "#79E02E",
-        "weight": 130,
+        "weight": 5,
         "terrainOctaves": [0.1, 0.1, 1, 1, 0.1, 0.1, 0.1, 0.1, 0.05],
         "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.03, 0.03, 0.05],
         "terrainYKeyPositions": [0.450, 0.532, 0.558, 0.610, 0.700],
@@ -27,7 +27,7 @@
         "code": "p&vflat highlands",
         "comment": "Very large scale high land flat lands",
         "hexcolor": "#79E02E",
-        "weight": 115,
+        "weight": 5,
         "terrainOctaves": [0.1, 0.1, 1, 1, 1, 0.1, 0.1, 0.1, 0.09],
         "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0.03, 0.03, 0.05],
         "terrainYKeyPositions": [0.5, 0.517, 0.529, 0.550, 0.604, 0.660, 0.691, 0.717, 0.767],
@@ -58,40 +58,8 @@
             "terrainYKeyThresholds": [1.0, 0.95, 0.90, 0.0]
           }
         ]
-      },
-      {
-        "code": "p&vsteppedsinkholes-large",
-        "comment": "Large stepped sink holes",
-        "hexcolor": "#CCAA00",
-        "weight": 8000,
-        "noiseScale": 0.00004,
-        "terrainOctaves": [0.15, 0.15, 0, 0, 0, 0.9, 0.9, 0.9, 0],
-        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
-        "terrainYKeyPositions": [0.40, 0.56, 0.72, 0.88],
-        "terrainYKeyThresholds": [1.0, 0.95, 0.90, 0.0],
-        "plateauCount": 3,
-        "baseRadius": 600,
-        "radiusStep": 0.88,
-        "radiusNoiseScale": 0.15,
-        "radiusNoiseAmplitude": 0.2
-      },
-      {
-        "code": "p&vsteppedsinkholes-mega",
-        "comment": "Huge multi-tiered sink holes",
-        "hexcolor": "#DDCC00",
-        "weight": 8000,
-        "noiseScale": 0.00003,
-        "terrainOctaves": [0.15, 0.15, 0, 0, 0, 0.9, 0.9, 0.9, 0],
-        "terrainOctaveThresholds": [0, 0, 0, 0, 0, 0, 0, 0, 0],
-        "terrainYKeyPositions": [0.38, 0.54, 0.70, 0.86],
-        "terrainYKeyThresholds": [1.0, 0.95, 0.90, 0.0],
-        "plateauCount": 3,
-        "baseRadius": 800,
-        "radiusStep": 0.90,
-        "radiusNoiseScale": 0.15,
-        "radiusNoiseAmplitude": 0.2
-      }
-    ],
+        }
+      ],
     "file": "game:worldgen/landforms.json",
     "side": "server"
   }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/worldgen/landformConfig.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/worldgen/landformConfig.json
@@ -2,21 +2,35 @@
   {
     "op": "add",
     "path": "/landforms/p&vsteppedsinkholes",
-    "value": {"weight": 8000},
+    "value": {"weight": 40},
     "file": "game:worldgen/landformConfig.json",
     "side": "Server"
   },
   {
     "op": "add",
-    "path": "/landforms/p&vsteppedsinkholes-large",
-    "value": {"weight": 8000},
+    "path": "/landforms/p&vflat lowlands",
+    "value": {"weight": 5},
     "file": "game:worldgen/landformConfig.json",
     "side": "Server"
   },
   {
     "op": "add",
-    "path": "/landforms/p&vsteppedsinkholes-mega",
-    "value": {"weight": 8000},
+    "path": "/landforms/p&vflat midlands",
+    "value": {"weight": 5},
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/landforms/p&vflat highlands",
+    "value": {"weight": 5},
+    "file": "game:worldgen/landformConfig.json",
+    "side": "Server"
+  },
+  {
+    "op": "add",
+    "path": "/landforms/p&vcliffislands",
+    "value": {"weight": 44},
     "file": "game:worldgen/landformConfig.json",
     "side": "Server"
   }


### PR DESCRIPTION
## Summary
- tone down custom patches by removing extra sinkhole variants
- add flat landforms and assign new weights
- boost sinkholes and cliffs in landformConfig and weights

## Testing
- `python -m json.tool < WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landformWeights.json`
- `python -m json.tool < WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/worldgen/landformConfig.json`

------
https://chatgpt.com/codex/tasks/task_b_687cea6846a883239f3c9e50b08fe7e3