### PR TITLE
Fix default landforms path

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -5,12 +5,17 @@ from opensimplex import OpenSimplex
 from PIL import Image
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+# The SelectedLandforms mod only ships a minimal
+# ``assets/game/worldgen/landforms.json`` file.  The previous
+# default pointed at ``assets/selectedlandforms/patches/landforms.json``
+# which does not exist and caused a ``FileNotFoundError`` when running
+# this script.  Update the path so the script works out of the box.
 DEFAULT_LANDFORMS_FILE = os.path.join(
     SCRIPT_DIR,
     "SelectedLandforms",
     "assets",
-    "selectedlandforms",
-    "patches",
+    "game",
+    "worldgen",
     "landforms.json",
 )
 OUTPUT_DIR = os.path.join(SCRIPT_DIR, "noise_samples")


### PR DESCRIPTION
## Summary
- fix `generate_noise_images.py` default landforms path

## Testing
- `./setup_env.sh`
- `python -m py_compile WorldgenMod/generate_noise_images.py`


------
https://chatgpt.com/codex/tasks/task_b_687d2ffa84188323a16f517e32eafad4