### PR TITLE
Filter noise script to custom landforms

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -63,7 +63,8 @@ with open(LANDFORMS_FILE) as f:
 
 # The SelectedLandforms patch file contains an array of operations instead of
 # a plain object. Extract the landform definitions regardless of format so this
-# script can render them without manual preprocessing.
+# script can render them without manual preprocessing. Only keep the custom
+# landforms defined for this mod.
 landforms = []
 if isinstance(patch_data, list):
     for op in patch_data:
@@ -72,6 +73,17 @@ if isinstance(patch_data, list):
             break
 else:
     landforms = patch_data.get("variants", [])
+
+CUSTOM_LANDFORMS = {
+    "sinkholeplateaus",
+    "dryseapillars",
+    "widepillarcliffs",
+    "drydeepstepmountains",
+    "landstepmountains",
+    "terraceplateaus",
+}
+
+landforms = [lf for lf in landforms if lf.get("code") in CUSTOM_LANDFORMS]
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Restrict `generate_noise_images.py` to render only the mod's custom landform codes

## Testing
- `python WorldgenMod/generate_noise_images.py --size 8 --landforms-file temp_custom.json`

------
https://chatgpt.com/codex/tasks/task_b_6898f904a1e483238f325490f5d6d68b