### PR TITLE
Add step mountain landforms and update preview script

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -30,6 +30,24 @@
       "terrainOctaves": [0, 0.90, 0.70, 0.45, 0, 0, 0, 0, 0],
       "terrainYKeyPositions": [0.00, 0.12, 0.22, 0.32, 0.41, 0.49, 0.56, 0.62, 0.67, 0.71],
       "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains maxcliff",
+      "comment": "Tall, hard-snapped plateaus (no rounding)",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.90, 0.70, 0.50, 0, 0, 0, 0, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains hybrid cliff",
+      "comment": "Tall plateaus, sheer cliffs, slight edge texture",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -30,6 +30,24 @@
       "terrainOctaves": [0, 0.90, 0.70, 0.45, 0, 0, 0, 0, 0],
       "terrainYKeyPositions": [0.00, 0.12, 0.22, 0.32, 0.41, 0.49, 0.56, 0.62, 0.67, 0.71],
       "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains maxcliff",
+      "comment": "Tall, hard-snapped plateaus (no rounding)",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.90, 0.70, 0.50, 0, 0, 0, 0, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains hybrid cliff",
+      "comment": "Tall plateaus, sheer cliffs, slight edge texture",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -24,6 +24,24 @@
       "terrainOctaves": [0, 0.81, 0.60, 0.6561, 0, 0.45, 0.25, 0.12, 0],
       "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.38, 0.44, 0.48, 0.53],
       "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains maxcliff",
+      "comment": "Tall, hard-snapped plateaus (no rounding)",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.90, 0.70, 0.50, 0, 0, 0, 0, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5]
+    },
+    {
+      "code": "step mountains hybrid cliff",
+      "comment": "Tall plateaus, sheer cliffs, slight edge texture",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -212,4 +212,5 @@ def render_landform(params, name):
 if __name__ == "__main__":
     for lf in landforms:
         code = lf.get("code", "landform")
-        render_landform(lf, code)
+        safe_code = code.replace(" ", "_")
+        render_landform(lf, safe_code)


### PR DESCRIPTION
## Summary
- add "step mountains maxcliff" and "step mountains hybrid cliff" variants to landforms data
- sanitize landform codes when generating preview images

## Testing
- `pip install -r requirements.txt`
- `python WorldgenMod/generate_noise_images.py --size 16`

------
https://chatgpt.com/codex/tasks/task_b_6899d3f581a48323a10767b5bde40499