### PR TITLE
Add step mountains 6-tier hybrid crisp landform

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -48,6 +48,15 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
       "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains 6-tier hybrid crisp",
+      "comment": "6 tiers, sheer cliffs, slight edge texture (oct2 & oct7 halved)",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -48,6 +48,15 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
       "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains 6-tier hybrid crisp",
+      "comment": "6 tiers, sheer cliffs, slight edge texture (oct2 & oct7 halved)",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -42,6 +42,15 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
       "terrainYKeyThresholds": [0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5]
+    },
+    {
+      "code": "step mountains 6-tier hybrid crisp",
+      "comment": "6 tiers, sheer cliffs, slight edge texture (oct2 & oct7 halved)",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add "step mountains 6-tier hybrid crisp" landform variant with six tiers and reduced octave amplitudes
- apply new key positions and thresholds across landform asset, data, and patch files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899d76ea2e48323a06e40ecbefbbc14