### PR TITLE
Add step mountains 6-tier hybrid crisp broad landform

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -57,6 +57,15 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
       "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
+    },
+    {
+      "code": "step mountains 6-tier hybrid crisp broad",
+      "comment": "6 tiers, crisp cliffs, maximum plateau width",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.1825, 0.50, 0, 0.20, 0.25, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -57,6 +57,15 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
       "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
+    },
+    {
+      "code": "step mountains 6-tier hybrid crisp broad",
+      "comment": "6 tiers, crisp cliffs, maximum plateau width",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.1825, 0.50, 0, 0.20, 0.25, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -51,6 +51,15 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
       "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
+    },
+    {
+      "code": "step mountains 6-tier hybrid crisp broad",
+      "comment": "6 tiers, crisp cliffs, maximum plateau width",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.1825, 0.50, 0, 0.20, 0.25, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -61,14 +61,20 @@ ZOOM = args.zoom
 with open(LANDFORMS_FILE) as f:
     patch_data = json.load(f)
 
-# The SelectedLandforms patch file contains an array of operations instead of
-# a plain object. Extract the landform definitions regardless of format so this
+# The SelectedLandforms patch file may contain an array of operations instead
+# of a plain object. Extract the landform definitions regardless of format so
+# every variation gets rendered.
 landforms = []
 if isinstance(patch_data, list):
     for op in patch_data:
-        if op.get("path") == "/variants" and isinstance(op.get("value"), list):
-            landforms = op["value"]
-            break
+        path = op.get("path", "")
+        if not path.startswith("/variants"):
+            continue
+        value = op.get("value")
+        if isinstance(value, list):
+            landforms.extend(value)
+        elif isinstance(value, dict):
+            landforms.append(value)
 else:
     landforms = patch_data.get("variants", [])
 


### PR DESCRIPTION
## Summary
- extend landform definitions with `step mountains 6-tier hybrid crisp broad`
- ensure noise preview script renders every landform variant

## Testing
- `python WorldgenMod/generate_noise_images.py --size 16`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899d897e6508323a368fb9b03799ec8