### PR TITLE
Introduce broad tall step mountain variant

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -2,70 +2,13 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "blend1",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.205, 0.15, 0.15, 0.10, 0.10, 0.04, 0.04, 0.0]
-    },
-    {
-      "code": "blend2",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.35, 0.30, 0.30, 0.25, 0.25, 0.20, 0.20, 0.15]
-    },
-    {
-      "code": "weddingcake",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "supercliffweddingcake",
-      "terrainOctaves": [0, 0.81, 0.60, 0.6561, 0, 0.45, 0.25, 0.12, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.38, 0.44, 0.48, 0.53],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "stepmountainvariation",
-      "terrainOctaves": [0, 0.90, 0.70, 0.45, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions": [0.00, 0.12, 0.22, 0.32, 0.41, 0.49, 0.56, 0.62, 0.67, 0.71],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains maxcliff",
-      "comment": "Tall, hard-snapped plateaus (no rounding)",
+      "code": "step mountains 6-tier broad tall",
+      "comment": "Broad plateaus, tall cliffs, max 6 tiers",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.90, 0.70, 0.50, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains hybrid cliff",
-      "comment": "Tall plateaus, sheer cliffs, slight edge texture",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains 6-tier hybrid crisp",
-      "comment": "6 tiers, sheer cliffs, slight edge texture (oct2 & oct7 halved)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
-    },
-    {
-      "code": "step mountains 6-tier hybrid crisp broad",
-      "comment": "6 tiers, crisp cliffs, maximum plateau width",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.1825, 0.50, 0, 0.20, 0.25, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2,70 +2,13 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "blend1",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.205, 0.15, 0.15, 0.10, 0.10, 0.04, 0.04, 0.0]
-    },
-    {
-      "code": "blend2",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.35, 0.30, 0.30, 0.25, 0.25, 0.20, 0.20, 0.15]
-    },
-    {
-      "code": "weddingcake",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "supercliffweddingcake",
-      "terrainOctaves": [0, 0.81, 0.60, 0.6561, 0, 0.45, 0.25, 0.12, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.38, 0.44, 0.48, 0.53],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "stepmountainvariation",
-      "terrainOctaves": [0, 0.90, 0.70, 0.45, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions": [0.00, 0.12, 0.22, 0.32, 0.41, 0.49, 0.56, 0.62, 0.67, 0.71],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains maxcliff",
-      "comment": "Tall, hard-snapped plateaus (no rounding)",
+      "code": "step mountains 6-tier broad tall",
+      "comment": "Broad plateaus, tall cliffs, max 6 tiers",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.90, 0.70, 0.50, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains hybrid cliff",
-      "comment": "Tall plateaus, sheer cliffs, slight edge texture",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains 6-tier hybrid crisp",
-      "comment": "6 tiers, sheer cliffs, slight edge texture (oct2 & oct7 halved)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
-    },
-    {
-      "code": "step mountains 6-tier hybrid crisp broad",
-      "comment": "6 tiers, crisp cliffs, maximum plateau width",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.1825, 0.50, 0, 0.20, 0.25, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2,64 +2,13 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "blend1",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.205, 0.15, 0.15, 0.10, 0.10, 0.04, 0.04, 0.0]
-    },
-    {
-      "code": "blend2",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.35, 0.30, 0.30, 0.25, 0.25, 0.20, 0.20, 0.15]
-    },
-    {
-      "code": "weddingcake",
-      "terrainOctaves": [0, 0.81, 0.50, 0.6561, 0, 0.531441, 0.30, 0.15, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.37, 0.42, 0.45, 0.50],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "supercliffweddingcake",
-      "terrainOctaves": [0, 0.81, 0.60, 0.6561, 0, 0.45, 0.25, 0.12, 0],
-      "terrainYKeyPositions": [0, 0.215, 0.25, 0.30, 0.31, 0.34, 0.38, 0.44, 0.48, 0.53],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains maxcliff",
-      "comment": "Tall, hard-snapped plateaus (no rounding)",
+      "code": "step mountains 6-tier broad tall",
+      "comment": "Broad plateaus, tall cliffs, max 6 tiers",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.90, 0.70, 0.50, 0, 0, 0, 0, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5]
-    },
-    {
-      "code": "step mountains hybrid cliff",
-      "comment": "Tall plateaus, sheer cliffs, slight edge texture",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.50, 0.60, 0.62, 0.68, 0.70, 0.80, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5,0.5]
-    },
-    {
-      "code": "step mountains 6-tier hybrid crisp",
-      "comment": "6 tiers, sheer cliffs, slight edge texture (oct2 & oct7 halved)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.0]
-    },
-    {
-      "code": "step mountains 6-tier hybrid crisp broad",
-      "comment": "6 tiers, crisp cliffs, maximum plateau width",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.1825, 0.50, 0, 0.20, 0.25, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -6,15 +6,14 @@ from PIL import Image
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # By default this script loads the landform definition from the
-# SelectedLandforms mod's patch file.
+# SelectedLandforms data file.
 DEFAULT_LANDFORMS_FILE = os.path.join(
     SCRIPT_DIR,
     "SelectedLandforms",
-    "assets",
-    "selectedlandforms",
-    "patches",
+    "data",
     "landforms.json",
 )
+DEFAULT_LANDFORM_CODE = "step mountains 6-tier broad tall"
 OUTPUT_DIR = os.path.join(SCRIPT_DIR, "noise_samples")
 WARP_SCALE = 0.01
 WARP_AMPLITUDE = 20.0
@@ -46,6 +45,11 @@ parser.add_argument(
     help="Path to landforms JSON (default: %(default)s)",
 )
 parser.add_argument(
+    "--code",
+    default=DEFAULT_LANDFORM_CODE,
+    help="Code of landform to render (default: %(default)s)",
+)
+parser.add_argument(
     "--zoom",
     type=float,
     default=1.0,
@@ -58,6 +62,7 @@ HEIGHTMAP = args.heightmap
 SEED = args.seed
 LANDFORMS_FILE = args.landforms_file
 ZOOM = args.zoom
+TARGET_CODE = args.code
 with open(LANDFORMS_FILE) as f:
     patch_data = json.load(f)
 
@@ -77,6 +82,9 @@ if isinstance(patch_data, list):
             landforms.append(value)
 else:
     landforms = patch_data.get("variants", [])
+
+if TARGET_CODE:
+    landforms = [lf for lf in landforms if lf.get("code") == TARGET_CODE]
 
 
 os.makedirs(OUTPUT_DIR, exist_ok=True)


### PR DESCRIPTION
## Summary
- replace all legacy landform variants with "step mountains 6-tier broad tall"
- default noise preview script to new landform data and filter by code

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile WorldgenMod/generate_noise_images.py`
- `python WorldgenMod/generate_noise_images.py --size 16 --landforms-file WorldgenMod/SelectedLandforms/data/landforms.json --code "step mountains 6-tier broad tall" --zoom 1.0`

------
https://chatgpt.com/codex/tasks/task_b_6899df1cf1e88323b01c9c294ec0446e