### PR TITLE
Add LIFT and AMP step mountain variants

### DIFF
--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -9,6 +9,22 @@
       "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
       "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
       "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier broad tall LIFT",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.10, 0.50, 0.62, 0.72, 0.82, 0.90, 0.97],
+      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier broad tall AMP",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.90, 0.85, 0.70, 0, 0.20, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -13,7 +13,7 @@ DEFAULT_LANDFORMS_FILE = os.path.join(
     "data",
     "landforms.json",
 )
-DEFAULT_LANDFORM_CODE = "step mountains 6-tier broad tall"
+DEFAULT_LANDFORM_CODE = ""
 OUTPUT_DIR = os.path.join(SCRIPT_DIR, "noise_samples")
 WARP_SCALE = 0.01
 WARP_AMPLITUDE = 20.0
@@ -47,7 +47,7 @@ parser.add_argument(
 parser.add_argument(
     "--code",
     default=DEFAULT_LANDFORM_CODE,
-    help="Code of landform to render (default: %(default)s)",
+    help="Code of landform to render (default: all)",
 )
 parser.add_argument(
     "--zoom",


### PR DESCRIPTION
## Summary
- add LIFT and AMP step mountain landforms
- make noise preview script render all landform variants by default

## Testing
- `pip install -r requirements.txt`
- `python WorldgenMod/generate_noise_images.py --size 16`


------
https://chatgpt.com/codex/tasks/task_b_6899e292f6088323bf1f3249409efbc4