### PR TITLE
Add soft and steep Y-threshold landform variants

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -9,6 +9,22 @@
       "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
       "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
       "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier broad tall soft",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.06, 0.05, 0.04, 0.03, 0.025, 0.02, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier broad tall steep",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.18, 0.15, 0.12, 0.09, 0.075, 0.06, 0.00]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -25,6 +25,22 @@
       "terrainOctaves": [0, 0.90, 0.85, 0.70, 0, 0.20, 0.15, 0.05, 0],
       "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
       "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier broad tall soft",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.06, 0.05, 0.04, 0.03, 0.025, 0.02, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier broad tall steep",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.18, 0.15, 0.12, 0.09, 0.075, 0.06, 0.00]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -6,11 +6,13 @@ from PIL import Image
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # By default this script loads the landform definition from the
-# SelectedLandforms data file.
+# SelectedLandforms patch file so previews match the in-game data.
 DEFAULT_LANDFORMS_FILE = os.path.join(
     SCRIPT_DIR,
     "SelectedLandforms",
-    "data",
+    "assets",
+    "selectedlandforms",
+    "patches",
     "landforms.json",
 )
 DEFAULT_LANDFORM_CODE = ""


### PR DESCRIPTION
## Summary
- expand landform patch definitions with soft and steep Y-key threshold variants
- point noise image generator at the patch file for accurate previews

## Testing
- `python WorldgenMod/generate_noise_images.py --size 8 --seed 0`


------
https://chatgpt.com/codex/tasks/task_b_6899e6ba9d9c8323bba9531384d552a1