### PR TITLE
Add landform variants with progressive y-key thresholds

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -25,6 +25,30 @@
       "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
       "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
       "terrainYKeyThresholds": [0.18, 0.15, 0.12, 0.09, 0.075, 0.06, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier broad tall inc1",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.22, 0.20, 0.18, 0.16, 0.15, 0.14, 0.10]
+    },
+    {
+      "code": "step mountains 6-tier broad tall inc2",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.32, 0.30, 0.28, 0.26, 0.25, 0.24, 0.20]
+    },
+    {
+      "code": "step mountains 6-tier broad tall inc3",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainYKeyThresholds": [0.42, 0.40, 0.38, 0.36, 0.35, 0.34, 0.30]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -188,6 +188,9 @@ def sample_height(params, x, z):
                 yfactor = t1 + (t2 - t1) * ratio
                 break
 
+    # Clamp to sane range so increased y-key variations do not overflow
+    yfactor = max(0.0, min(yfactor, 1.0))
+
     total = max(0.0, min(total * yfactor * step_factor, 1.0))
     return base_height + height_offset * total
 


### PR DESCRIPTION
## Summary
- extend step mountain landforms with three additional variants that increase `terrainYKeyThresholds` in 0.1 steps
- clamp interpolated y-key factor in noise rendering script to handle expanded threshold ranges

## Testing
- `python WorldgenMod/generate_noise_images.py --size 16 --landforms-file WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json`

------
https://chatgpt.com/codex/tasks/task_b_6899e8be4a6c83239faa7af870335d09