### PR TITLE
Add new step mountain landforms and update preview renderer

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -2,13 +2,29 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier broad tall",
-      "comment": "Broad plateaus, tall cliffs, max 6 tiers",
+      "code": "step mountains 6-tier (vanilla-like)",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainOctaves": [0, 0.81, 0.729, 0.6561, 0, 0.531441, 0.4, 0.20, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
       "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier (hybrid)",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
+    },
+    {
+      "code": "step mountains self test",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2,53 +2,29 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier broad tall",
-      "comment": "Broad plateaus, tall cliffs, max 6 tiers",
+      "code": "step mountains 6-tier (vanilla-like)",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainOctaves": [0, 0.81, 0.729, 0.6561, 0, 0.531441, 0.4, 0.20, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
       "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
     },
     {
-      "code": "step mountains 6-tier broad tall soft",
+      "code": "step mountains 6-tier (hybrid)",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
-      "terrainYKeyThresholds": [0.06, 0.05, 0.04, 0.03, 0.025, 0.02, 0.00]
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
     },
     {
-      "code": "step mountains 6-tier broad tall steep",
+      "code": "step mountains self test",
+      "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
-      "terrainYKeyThresholds": [0.18, 0.15, 0.12, 0.09, 0.075, 0.06, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier broad tall inc1",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
-      "terrainYKeyThresholds": [0.22, 0.20, 0.18, 0.16, 0.15, 0.14, 0.10]
-    },
-    {
-      "code": "step mountains 6-tier broad tall inc2",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
-      "terrainYKeyThresholds": [0.32, 0.30, 0.28, 0.26, 0.25, 0.24, 0.20]
-    },
-    {
-      "code": "step mountains 6-tier broad tall inc3",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
-      "terrainYKeyThresholds": [0.42, 0.40, 0.38, 0.36, 0.35, 0.34, 0.30]
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2,45 +2,29 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier broad tall",
-      "comment": "Broad plateaus, tall cliffs, max 6 tiers",
+      "code": "step mountains 6-tier (vanilla-like)",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
+      "terrainOctaves": [0, 0.81, 0.729, 0.6561, 0, 0.531441, 0.4, 0.20, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
       "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
     },
     {
-      "code": "step mountains 6-tier broad tall LIFT",
+      "code": "step mountains 6-tier (hybrid)",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.10, 0.50, 0.62, 0.72, 0.82, 0.90, 0.97],
-      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
     },
     {
-      "code": "step mountains 6-tier broad tall AMP",
+      "code": "step mountains self test",
+      "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.90, 0.85, 0.70, 0, 0.20, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
-      "terrainYKeyThresholds": [0.10, 0.08, 0.08, 0.06, 0.05, 0.04, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier broad tall soft",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
-      "terrainYKeyThresholds": [0.06, 0.05, 0.04, 0.03, 0.025, 0.02, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier broad tall steep",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.72, 0.65, 0, 0.25, 0.15, 0.05, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.93],
-      "terrainYKeyThresholds": [0.18, 0.15, 0.12, 0.09, 0.075, 0.06, 0.00]
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -5,14 +5,12 @@ from opensimplex import OpenSimplex
 from PIL import Image
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-# By default this script loads the landform definition from the
-# SelectedLandforms patch file so previews match the in-game data.
+# By default this script loads the landform definitions from the
+# SelectedLandforms data file so previews match the in-game data.
 DEFAULT_LANDFORMS_FILE = os.path.join(
     SCRIPT_DIR,
     "SelectedLandforms",
-    "assets",
-    "selectedlandforms",
-    "patches",
+    "data",
     "landforms.json",
 )
 DEFAULT_LANDFORM_CODE = ""


### PR DESCRIPTION
## Summary
- replace existing landform variants with vanilla-like, hybrid, and self test step mountain definitions
- load landform data from SelectedLandforms/data in renderer script

## Testing
- `python WorldgenMod/generate_noise_images.py --size 16 --seed 0`

------
https://chatgpt.com/codex/tasks/task_b_6899ee0f5f708323a207fe0e707c2800