### PR TITLE
Add y-key threshold landform variations

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -25,6 +25,96 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
       "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
+    },
+    {
+      "code": "step mountains y key test",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 1, 1, 1, 1, 1, 1]
+    },
+    {
+      "code": "step mountains y key test 0.9",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9]
+    },
+    {
+      "code": "step mountains y key test 0.8",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8]
+    },
+    {
+      "code": "step mountains y key test 0.7",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7]
+    },
+    {
+      "code": "step mountains y key test 0.6",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]
+    },
+    {
+      "code": "step mountains y key test 0.5",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains y key test 0.4",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4]
+    },
+    {
+      "code": "step mountains y key test 0.3",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
+    },
+    {
+      "code": "step mountains y key test 0.2",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+    },
+    {
+      "code": "step mountains y key test 0.1",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -25,6 +25,96 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
       "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
+    },
+    {
+      "code": "step mountains y key test",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 1, 1, 1, 1, 1, 1]
+    },
+    {
+      "code": "step mountains y key test 0.9",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9]
+    },
+    {
+      "code": "step mountains y key test 0.8",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8]
+    },
+    {
+      "code": "step mountains y key test 0.7",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7]
+    },
+    {
+      "code": "step mountains y key test 0.6",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]
+    },
+    {
+      "code": "step mountains y key test 0.5",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains y key test 0.4",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4]
+    },
+    {
+      "code": "step mountains y key test 0.3",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
+    },
+    {
+      "code": "step mountains y key test 0.2",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+    },
+    {
+      "code": "step mountains y key test 0.1",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -25,6 +25,96 @@
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
       "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
+    },
+    {
+      "code": "step mountains y key test",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 1, 1, 1, 1, 1, 1]
+    },
+    {
+      "code": "step mountains y key test 0.9",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9]
+    },
+    {
+      "code": "step mountains y key test 0.8",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8]
+    },
+    {
+      "code": "step mountains y key test 0.7",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7]
+    },
+    {
+      "code": "step mountains y key test 0.6",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]
+    },
+    {
+      "code": "step mountains y key test 0.5",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+    },
+    {
+      "code": "step mountains y key test 0.4",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4]
+    },
+    {
+      "code": "step mountains y key test 0.3",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
+    },
+    {
+      "code": "step mountains y key test 0.2",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
+    },
+    {
+      "code": "step mountains y key test 0.1",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
+      "terrainYKeyThresholds": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -1,6 +1,7 @@
 import json
 import os
 import argparse
+import re
 from opensimplex import OpenSimplex
 from PIL import Image
 
@@ -229,5 +230,5 @@ def render_landform(params, name):
 if __name__ == "__main__":
     for lf in landforms:
         code = lf.get("code", "landform")
-        safe_code = code.replace(" ", "_")
+        safe_code = re.sub(r"[^0-9A-Za-z_-]", "_", code)
         render_landform(lf, safe_code)


### PR DESCRIPTION
## Summary
- add step-mountain y-key test landform plus nine variants with progressively reduced terrainYKeyThresholds
- sanitize output filenames in noise generator script to handle special characters in codes

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile WorldgenMod/generate_noise_images.py`
- `python WorldgenMod/generate_noise_images.py --code "step mountains y key test 0.9" --size 16`


------
https://chatgpt.com/codex/tasks/task_b_6899f1bf91a4832395c4847468e7c4ab