### PR TITLE
Add step mountains y key sym variant

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -2,119 +2,13 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier (vanilla-like)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.729, 0.6561, 0, 0.531441, 0.4, 0.20, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier (hybrid)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
-    },
-    {
-      "code": "step mountains self test",
+      "code": "step mountains y key sym",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
       "weight": 1,
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
-    },
-    {
-      "code": "step mountains y key test",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 1, 1, 1, 1, 1]
-    },
-    {
-      "code": "step mountains y key test 0.9",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9]
-    },
-    {
-      "code": "step mountains y key test 0.8",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8]
-    },
-    {
-      "code": "step mountains y key test 0.7",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7]
-    },
-    {
-      "code": "step mountains y key test 0.6",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]
-    },
-    {
-      "code": "step mountains y key test 0.5",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains y key test 0.4",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4]
-    },
-    {
-      "code": "step mountains y key test 0.3",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
-    },
-    {
-      "code": "step mountains y key test 0.2",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
-    },
-    {
-      "code": "step mountains y key test 0.1",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+      "terrainYKeyThresholds": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2,119 +2,13 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier (vanilla-like)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.729, 0.6561, 0, 0.531441, 0.4, 0.20, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier (hybrid)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
-    },
-    {
-      "code": "step mountains self test",
+      "code": "step mountains y key sym",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
       "weight": 1,
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
-    },
-    {
-      "code": "step mountains y key test",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 1, 1, 1, 1, 1]
-    },
-    {
-      "code": "step mountains y key test 0.9",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9]
-    },
-    {
-      "code": "step mountains y key test 0.8",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8]
-    },
-    {
-      "code": "step mountains y key test 0.7",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7]
-    },
-    {
-      "code": "step mountains y key test 0.6",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]
-    },
-    {
-      "code": "step mountains y key test 0.5",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains y key test 0.4",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4]
-    },
-    {
-      "code": "step mountains y key test 0.3",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
-    },
-    {
-      "code": "step mountains y key test 0.2",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
-    },
-    {
-      "code": "step mountains y key test 0.1",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+      "terrainYKeyThresholds": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2,119 +2,13 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier (vanilla-like)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.729, 0.6561, 0, 0.531441, 0.4, 0.20, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier (hybrid)",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.55, 0.65, 0.75, 0.85, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.10, 0.08, 0.06, 0.05, 0.04, 0.00]
-    },
-    {
-      "code": "step mountains self test",
+      "code": "step mountains y key sym",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
       "weight": 1,
       "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 0.75, 0.5, 0.30, 0.20, 0.08, 0.0]
-    },
-    {
-      "code": "step mountains y key test",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 1, 1, 1, 1, 1]
-    },
-    {
-      "code": "step mountains y key test 0.9",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.9]
-    },
-    {
-      "code": "step mountains y key test 0.8",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.8, 0.8, 0.8, 0.8, 0.8, 0.8, 0.8]
-    },
-    {
-      "code": "step mountains y key test 0.7",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.7, 0.7, 0.7, 0.7, 0.7, 0.7, 0.7]
-    },
-    {
-      "code": "step mountains y key test 0.6",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6]
-    },
-    {
-      "code": "step mountains y key test 0.5",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
-    },
-    {
-      "code": "step mountains y key test 0.4",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4]
-    },
-    {
-      "code": "step mountains y key test 0.3",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3]
-    },
-    {
-      "code": "step mountains y key test 0.2",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
-    },
-    {
-      "code": "step mountains y key test 0.1",
-      "comment": "Raised terrain with mountains that have several steps in them",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+      "terrainYKeyThresholds": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -7,14 +7,16 @@ from PIL import Image
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # By default this script loads the landform definitions from the
-# SelectedLandforms data file so previews match the in-game data.
+# SelectedLandforms patch file so previews match the in-game data.
 DEFAULT_LANDFORMS_FILE = os.path.join(
     SCRIPT_DIR,
     "SelectedLandforms",
-    "data",
+    "assets",
+    "selectedlandforms",
+    "patches",
     "landforms.json",
 )
-DEFAULT_LANDFORM_CODE = ""
+DEFAULT_LANDFORM_CODE = "step mountains y key sym"
 OUTPUT_DIR = os.path.join(SCRIPT_DIR, "noise_samples")
 WARP_SCALE = 0.01
 WARP_AMPLITUDE = 20.0


### PR DESCRIPTION
## Summary
- replace landform variant lists with a single `step mountains y key sym` variant
- default noise rendering script to patched landforms and new variant code

## Testing
- `python WorldgenMod/generate_noise_images.py --size 32`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899f5ca6e548323a9f02c045d24b0d4