### PR TITLE
Add new step mountain landforms and update rendering script

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -2,13 +2,40 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains y key sym",
+      "code": "step mountains 6-tier hybrid crisp",
+      "comment": "Octave 2 & 7 halved; crisp plateaus across 6 tiers",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.03, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier hybrid top-lock",
+      "comment": "Octave 2 & 7 halved; crisp tiers with strong attraction to top bands",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.10, 0.00]
+    },
+    {
+      "code": "step mountains custom",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.6, 0.62, 0.68, 0.7, 0.8, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 1, 0.41, 0.3, 0.30, 0.2, 0.20, 0.08, 0.08, 0.0]
+    },
+    {
+      "code": "step mountains custom 6",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9]
+      "terrainYKeyThresholds": [1, 1, 0.41, 0.30, 0.20, 0.08, 0.0]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2,13 +2,40 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains y key sym",
+      "code": "step mountains 6-tier hybrid crisp",
+      "comment": "Octave 2 & 7 halved; crisp plateaus across 6 tiers",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.03, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier hybrid top-lock",
+      "comment": "Octave 2 & 7 halved; crisp tiers with strong attraction to top bands",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.10, 0.00]
+    },
+    {
+      "code": "step mountains custom",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.6, 0.62, 0.68, 0.7, 0.8, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 1, 0.41, 0.3, 0.30, 0.2, 0.20, 0.08, 0.08, 0.0]
+    },
+    {
+      "code": "step mountains custom 6",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9]
+      "terrainYKeyThresholds": [1, 1, 0.41, 0.30, 0.20, 0.08, 0.0]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2,13 +2,40 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains y key sym",
+      "code": "step mountains 6-tier hybrid crisp",
+      "comment": "Octave 2 & 7 halved; crisp plateaus across 6 tiers",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.03, 0.00]
+    },
+    {
+      "code": "step mountains 6-tier hybrid top-lock",
+      "comment": "Octave 2 & 7 halved; crisp tiers with strong attraction to top bands",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.10, 0.00]
+    },
+    {
+      "code": "step mountains custom",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
       "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.1, 0],
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0, 0.43, 0.5, 0.6, 0.62, 0.68, 0.7, 0.8, 0.84, 0.9],
+      "terrainYKeyThresholds": [1, 1, 0.41, 0.3, 0.30, 0.2, 0.20, 0.08, 0.08, 0.0]
+    },
+    {
+      "code": "step mountains custom 6",
+      "comment": "Raised terrain with mountains that have several steps in them",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
       "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9]
+      "terrainYKeyThresholds": [1, 1, 0.41, 0.30, 0.20, 0.08, 0.0]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -16,7 +16,7 @@ DEFAULT_LANDFORMS_FILE = os.path.join(
     "patches",
     "landforms.json",
 )
-DEFAULT_LANDFORM_CODE = "step mountains y key sym"
+DEFAULT_LANDFORM_CODE = ""
 OUTPUT_DIR = os.path.join(SCRIPT_DIR, "noise_samples")
 WARP_SCALE = 0.01
 WARP_AMPLITUDE = 20.0


### PR DESCRIPTION
## Summary
- replace previous landform variant with four new step mountain configurations
- default noise-image script to render all landforms

## Testing
- `python WorldgenMod/generate_noise_images.py --size 32 --seed 0 --zoom 1.0`

------
https://chatgpt.com/codex/tasks/task_b_6899f9beea488323950c9ab184e3c055