### PR TITLE
Favor step mountains in SelectedLandforms mod

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -2,40 +2,2379 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier hybrid crisp",
-      "comment": "Octave 2 & 7 halved; crisp plateaus across 6 tiers",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.03, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier hybrid top-lock",
-      "comment": "Octave 2 & 7 halved; crisp tiers with strong attraction to top bands",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.10, 0.00]
-    },
-    {
       "code": "step mountains custom",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.6, 0.62, 0.68, 0.7, 0.8, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 0.41, 0.3, 0.30, 0.2, 0.20, 0.08, 0.08, 0.0]
+      "weight": 80,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.365,
+        0.6561,
+        0,
+        0.531441,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7,
+        0.8,
+        0.84,
+        0.9
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.41,
+        0.3,
+        0.3,
+        0.2,
+        0.2,
+        0.08,
+        0.08,
+        0.0
+      ]
     },
     {
-      "code": "step mountains custom 6",
+      "code": "steppedsinkholes",
+      "comment": "Stepped sink holes",
+      "hexcolor": "#AAAA00",
+      "weight": 15,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.431,
+        0.436,
+        0.457,
+        0.462,
+        0.484,
+        0.489,
+        0.513,
+        0.518,
+        0.525
+      ],
+      "terrainYKeyThresholds": [
+        0.999,
+        0.814,
+        0.816,
+        0.761,
+        0.76,
+        0.719,
+        0.718,
+        0.688,
+        0.0
+      ],
+      "mutations": [
+        {
+          "code": "steppedsinkhold-cavemut",
+          "comment": "Cave mutation",
+          "chance": 0.15,
+          "hexcolor": "#AAAA00",
+          "terrainYKeyPositions": [
+            0.399,
+            0.419,
+            0.427,
+            0.437,
+            0.457,
+            0.462,
+            0.484,
+            0.489,
+            0.513,
+            0.518,
+            0.525
+          ],
+          "terrainYKeyThresholds": [
+            1.0,
+            0.816,
+            0.035,
+            0.808,
+            0.816,
+            0.761,
+            0.76,
+            0.719,
+            0.718,
+            0.688,
+            0.0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "largeislands",
+      "comment": "lots of water, large island and a few tiny islands",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.271,
+        0.433,
+        0.455,
+        0.46,
+        0.801,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        0.767,
+        0.368,
+        0.288,
+        0.24,
+        0.078,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticflatlands",
+      "comment": "Very large scale flat lands",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.41,
+        0.518
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticmountains-ledged",
+      "comment": "Very large scale mountains with ledges",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.15,
+        0.15,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.396,
+        0.428,
+        0.433,
+        0.468,
+        0.475,
+        0.656,
+        0.661,
+        0.718,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.71,
+        0.65,
+        0.584,
+        0.557,
+        0.524,
+        0.342,
+        0.287,
+        0.29,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticmountains-quintupleledged",
+      "comment": "Very large scale mountains with ledges",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.15,
+        0.15,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.396,
+        0.428,
+        0.433,
+        0.468,
+        0.475,
+        0.513,
+        0.518,
+        0.586,
+        0.646,
+        0.651,
+        0.718,
+        0.797,
+        0.803,
+        0.882,
+        0.89,
+        0.963
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.71,
+        0.65,
+        0.584,
+        0.557,
+        0.524,
+        0.479,
+        0.41,
+        0.41,
+        0.362,
+        0.287,
+        0.29,
+        0.208,
+        0.127,
+        0.13,
+        0.055,
+        0.0
+      ]
+    },
+    {
+      "code": "islandchess",
+      "comment": "checkboard of land and water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "minTemp": -4,
+      "minRain": 120,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.1
+      ],
+      "terrainYKeyPositions": [
+        0.41,
+        0.445
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.0
+      ]
+    },
+    {
+      "code": "needledflatlands",
+      "comment": "Flat lands with very thin small hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.1,
+        0.5,
+        0.75
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.476,
+        0.49,
+        0.545,
+        0.559
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.261,
+        0.167,
+        0.0
+      ]
+    },
+    {
+      "code": "Realistic mountains",
+      "comment": "Very large scale mountains",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.405,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.593,
+        0.0
+      ]
+    },
+    {
+      "code": "siberiansinkholes",
+      "comment": "Siberian sink holes",
+      "hexcolor": "#AAAA00",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.335,
+        0.468,
+        0.525,
+        0.545
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.978,
+        0.692,
+        0.0
+      ]
+    },
+    {
+      "code": "shallowmillionstepmountains",
+      "comment": "More shallow Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.418,
+        0.449,
+        0.474,
+        0.502,
+        0.507,
+        0.526,
+        0.539,
+        0.556,
+        0.563,
+        0.583,
+        0.589,
+        0.605,
+        0.61,
+        0.623,
+        0.63,
+        0.647,
+        0.652,
+        0.669
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.493,
+        0.439,
+        0.43,
+        0.397,
+        0.395,
+        0.36,
+        0.359,
+        0.319,
+        0.314,
+        0.287,
+        0.284,
+        0.257,
+        0.255,
+        0.224,
+        0.22,
+        0.187,
+        0.0
+      ]
+    },
+    {
+      "code": "mediummillionstepmountains",
+      "comment": "More shallow Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.417,
+        0.458,
+        0.483,
+        0.514,
+        0.523,
+        0.542,
+        0.548,
+        0.59,
+        0.595,
+        0.617,
+        0.623,
+        0.639,
+        0.644,
+        0.657,
+        0.662,
+        0.686,
+        0.701,
+        0.711
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.487,
+        0.439,
+        0.441,
+        0.4,
+        0.401,
+        0.363,
+        0.359,
+        0.317,
+        0.314,
+        0.287,
+        0.284,
+        0.257,
+        0.255,
+        0.222,
+        0.218,
+        0.19,
+        0.0
+      ]
+    },
+    {
+      "code": "tallmillionstepmountains",
+      "comment": "Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.413,
+        0.498,
+        0.547,
+        0.552,
+        0.582,
+        0.592,
+        0.62,
+        0.63,
+        0.657,
+        0.665,
+        0.687,
+        0.692,
+        0.715,
+        0.722,
+        0.745,
+        0.752,
+        0.782,
+        0.843,
+        0.892
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.532,
+        0.53,
+        0.482,
+        0.48,
+        0.442,
+        0.442,
+        0.402,
+        0.402,
+        0.37,
+        0.37,
+        0.34,
+        0.34,
+        0.307,
+        0.303,
+        0.27,
+        0.27,
+        0.007,
+        0.0
+      ]
+    },
+    {
+      "code": "roughflatlands",
+      "comment": "Rough near sea level flat lands",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.438,
+        0.5,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.267,
+        0.0
+      ]
+    },
+    {
+      "code": "roughlabyrinth",
+      "comment": "Rough labyrinth lands",
+      "hexcolor": "#A9810F",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0.5
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.51
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0
+      ]
+    },
+    {
+      "code": "supersmoothills",
+      "comment": "Super Smooth hills",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0.4,
+        0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0
+      ]
+    },
+    {
+      "code": "largelake",
+      "comment": "Just water :P",
+      "hexcolor": "#0000FF",
+      "weight": 0.10869565217391304,
+      "minTemp": 0,
+      "maxTemp": 50,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.36,
+        0.4,
+        0.43
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.6,
+        0
+      ]
+    },
+    {
+      "code": "cold glaciers",
+      "comment": "",
+      "hexcolor": "#000099",
+      "weight": 0.10869565217391304,
+      "minTemp": -20,
+      "maxTemp": -19.5,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0.25,
+        0,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.426,
+        0.431,
+        0.588,
+        0.601,
+        0.643
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.957,
+        0.962,
+        0.022,
+        0.0
+      ]
+    },
+    {
+      "code": "cold mountain range",
+      "comment": "",
+      "hexcolor": "#000099",
+      "weight": 0.10869565217391304,
+      "minTemp": -20,
+      "maxTemp": -19.5,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.405,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.593,
+        0.0
+      ]
+    },
+    {
+      "code": "humongous mountain",
+      "comment": "humongous mountains with caverns in them",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        2,
+        1,
+        1,
+        0,
+        0.0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.33,
+        0.37,
+        0.41,
+        0.422,
+        0.5,
+        0.683,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.87,
+        0.842,
+        0.643,
+        0.988,
+        0.87,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.25,
+          "code": "humongous mountain, cavernless",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0.0,
+            0.423,
+            0.5,
+            0.683,
+            1.0
+          ],
+          "terrainYKeyThresholds": [
+            1.0,
+            1.0,
+            0.988,
+            0.87,
+            0.0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "hillplateu",
+      "comment": "high plateu with hills on top",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.25,
+        0.25,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.432,
+        0.611,
+        0.712,
+        0.735,
+        0.885
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.952,
+        0.66,
+        0.629,
+        0.0
+      ]
+    },
+    {
+      "code": "smallshallowislands",
+      "comment": "Small shallow islands with very small hills and lots of water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.36,
+        0.4,
+        0.43,
+        0.44,
+        0.497
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.8,
+        0.3,
+        0.17,
+        0.0
+      ]
+    },
+    {
+      "code": "shallowislands",
+      "comment": "Medium sized shallow islands with small bumps and lots of water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.25
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.36,
+        0.41,
+        0.43,
+        0.44,
+        0.471,
+        0.497,
+        0.54
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.805,
+        0.3,
+        0.192,
+        0.105,
+        0.016,
+        0.0
+      ]
+    },
+    {
+      "code": "cliffy rolling hills",
+      "comment": "cliffy rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0,
+        0,
+        0.5,
+        0.3,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.74,
+        0.75
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "superflatrarebumps",
+      "comment": "very flat lands with occasional bumps",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.425,
+        0.45,
+        0.56,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.3,
+        0
+      ]
+    },
+    {
+      "code": "veryflat",
+      "comment": "Very flat lands near sea level",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.01,
+        0.01
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.425,
+        0.45,
+        0.455
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.4,
+        0.0
+      ]
+    },
+    {
+      "code": "flatmanybumps",
+      "comment": "Flat land with many bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.59049,
+        0.531441,
+        0.4,
+        0.6,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.43,
+        0.55
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.3,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.4,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "veryflatmanybumps",
+      "comment": "Very flat land with many bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.59049,
+        0.531441,
+        0.4,
+        0.6,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.4,
+        0.43,
+        0.498
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.8,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.3,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.4,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "above sealevel flat grasslands",
+      "comment": "above sealevel flat grasslands with a single step",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        0.81,
+        0.729,
+        0.5,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.1,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.44,
+        0.5,
+        0.52,
+        0.6,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.5,
+        0.48,
+        0.15,
+        0.0
+      ]
+    },
+    {
+      "code": "rollinghills",
+      "comment": "near sealevel rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.2,
+        0.2,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.42,
+        0.5,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0.8,
+        0
+      ]
+    },
+    {
+      "code": "lowrollinghills",
+      "comment": "near sealevel low rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.2,
+        0.4,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.43,
+        0.55
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.15,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.41,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "cliffislands",
+      "comment": "Islands with tall cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        1,
+        0.2,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.41,
+        0.432,
+        0.44,
+        0.498,
+        0.547,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.432,
+        0.402,
+        0.393,
+        0.167,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.4,
+          "code": "sharp cliff islands",
+          "hexcolor": "#79E02E",
+          "terrainOctaves": [
+            0.9,
+            0.81,
+            0.729,
+            0.6561,
+            0.59049,
+            0.531441,
+            1,
+            0.3,
+            0.4
+          ]
+        }
+      ]
+    },
+    {
+      "code": "smallcliffislands",
+      "comment": "Islands with many small cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.4,
+        0.6,
+        0.5,
+        1,
+        0.3,
+        0.9
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2
+      ],
+      "terrainYKeyPositions": [
+        0.188,
+        0.355,
+        0.391,
+        0.427,
+        0.433,
+        0.46,
+        0.486,
+        0.542
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.9,
+        0.527,
+        0.398,
+        0.393,
+        0.167,
+        0.0
+      ]
+    },
+    {
+      "code": "bumplands",
+      "comment": "flat with small and big bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1.0,
+        0,
+        0.2,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.7,
+        0.75,
+        0.76
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.7,
+        0.5,
+        0.2,
+        0.02,
+        0
+      ]
+    },
+    {
+      "code": "roundclifflandshilly",
+      "comment": "round clifflands (more hilly, less easily traversable)",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        1.0,
+        0,
+        0.2,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.42,
+        0.43,
+        0.45,
+        0.7,
+        0.75,
+        0.76
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.9,
+        0.7,
+        0.5,
+        0.2,
+        0.02,
+        0
+      ]
+    },
+    {
+      "code": "sparsecliffyswamplands",
+      "comment": "Swamp lands with sparse short 2-stepped cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.1,
+        0.2,
+        0.3,
+        1.0,
+        0.4,
+        0.4,
+        0.5,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.154,
+        0.401,
+        0.43,
+        0.446,
+        0.465,
+        0.47,
+        0.488,
+        0.498,
+        0.521
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.99,
+        0.682,
+        0.303,
+        0.297,
+        0.225,
+        0.222,
+        0.17,
+        0.0
+      ]
+    },
+    {
+      "code": "densecliffyswamplands",
+      "comment": "Swamp lands with dense tall cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.1,
+        0.2,
+        0.3,
+        1.0,
+        0.4,
+        0.4,
+        0.5,
+        0.35
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.42,
+        0.43,
+        0.45,
+        0.7,
+        0.75
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.9,
+        0.7,
+        0.4,
+        0.1,
+        0
+      ]
+    },
+    {
+      "code": "deep water step mountains",
+      "comment": "Step mountains in deep water",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.45,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.65,
+        0.39,
+        0.2,
+        0.2,
+        0.05,
+        0.0
+      ]
+    },
+    {
+      "code": "step mountains",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 0.41, 0.30, 0.20, 0.08, 0.0]
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7,
+        0.8,
+        0.84,
+        0.9
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.41,
+        0.3,
+        0.3,
+        0.2,
+        0.2,
+        0.08,
+        0.08,
+        0.0
+      ]
+    },
+    {
+      "code": "flathillvalley",
+      "comment": "Flat lands with occasional hills and valleys",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0.3,
+        0,
+        0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.3,
+        0.3,
+        0.3,
+        0.3,
+        0.3,
+        0.2,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.443,
+        0.463,
+        0.508,
+        0.548,
+        0.556,
+        0.598,
+        0.699,
+        0.8
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.573,
+        0.373,
+        0.3,
+        0.272,
+        0.26,
+        0.11,
+        0.0
+      ]
+    },
+    {
+      "code": "hillsflatsandislands",
+      "comment": "A colorful mix of flats, hillgroups and islands",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        1,
+        1,
+        1,
+        0.5,
+        0.2,
+        0.4,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.397,
+        0.415,
+        0.438,
+        0.459,
+        0.548,
+        0.602,
+        0.684,
+        0.711,
+        0.752
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.77,
+        0.517,
+        0.287,
+        0.197,
+        0.117,
+        0.047,
+        0.047,
+        0.0
+      ]
+    },
+    {
+      "code": "smallsealevelplateus",
+      "comment": "Small many near sea level plateus",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.25,
+        0.3,
+        1,
+        1,
+        0.7,
+        0.15
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.43,
+        0.45,
+        0.455,
+        0.495,
+        0.505,
+        0.525,
+        0.535
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        1,
+        0.63,
+        0.27,
+        0.27,
+        0.09,
+        0.09,
+        0
+      ]
+    },
+    {
+      "code": "mediumseapillars",
+      "comment": "medium stepped pillars in the sea",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        1,
+        0.7,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.15
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.365,
+        0.43,
+        0.443,
+        0.51,
+        0.52,
+        0.56,
+        0.57,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.4,
+        0.227,
+        0.223,
+        0.17,
+        0.168,
+        0.13,
+        0.0
+      ]
+    },
+    {
+      "code": "mediumlandpillars",
+      "comment": "medium stepped pillars on flat land",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.4,
+        1,
+        0.7,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.435,
+        0.45,
+        0.5,
+        0.54,
+        0.55,
+        0.59,
+        0.6,
+        0.64,
+        0.66
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.22,
+        0.21,
+        0.18,
+        0.17,
+        0.14,
+        0.13,
+        0
+      ]
+    },
+    {
+      "code": "marsh",
+      "comment": "very flat lands with small rough hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "bumpy marsh",
+      "comment": "Near sea lavel lakes with small round hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "flatmarsh",
+      "comment": "very flat lands with rare small bumps",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.35,
+        0.15,
+        0
+      ]
+    },
+    {
+      "code": "deathmarsh",
+      "comment": "some strange pool here",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.08,
+        0.4,
+        0.425,
+        0.43,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.66,
+        0.55,
+        0.7,
+        0.55,
+        0.35,
+        0.15,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.5,
+          "code": "deathmarsh hill",
+          "hexcolor": "#79E02E",
+          "terrainOctaves": [
+            0,
+            0,
+            0,
+            0,
+            0.2,
+            0.2,
+            1,
+            0.5,
+            0
+          ],
+          "terrainOctaveThresholds": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.4,
+            0.1,
+            0
+          ],
+          "terrainYKeyPositions": [
+            0,
+            0.08,
+            0.4,
+            0.42,
+            0.43,
+            0.44,
+            0.51,
+            0.7
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            0.66,
+            0.55,
+            0.7,
+            0.55,
+            0.5,
+            0.4,
+            0
+          ]
+        }
+      ]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2,40 +2,2379 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier hybrid crisp",
-      "comment": "Octave 2 & 7 halved; crisp plateaus across 6 tiers",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.03, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier hybrid top-lock",
-      "comment": "Octave 2 & 7 halved; crisp tiers with strong attraction to top bands",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.10, 0.00]
-    },
-    {
       "code": "step mountains custom",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.6, 0.62, 0.68, 0.7, 0.8, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 0.41, 0.3, 0.30, 0.2, 0.20, 0.08, 0.08, 0.0]
+      "weight": 80,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.365,
+        0.6561,
+        0,
+        0.531441,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7,
+        0.8,
+        0.84,
+        0.9
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.41,
+        0.3,
+        0.3,
+        0.2,
+        0.2,
+        0.08,
+        0.08,
+        0.0
+      ]
     },
     {
-      "code": "step mountains custom 6",
+      "code": "steppedsinkholes",
+      "comment": "Stepped sink holes",
+      "hexcolor": "#AAAA00",
+      "weight": 15,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.431,
+        0.436,
+        0.457,
+        0.462,
+        0.484,
+        0.489,
+        0.513,
+        0.518,
+        0.525
+      ],
+      "terrainYKeyThresholds": [
+        0.999,
+        0.814,
+        0.816,
+        0.761,
+        0.76,
+        0.719,
+        0.718,
+        0.688,
+        0.0
+      ],
+      "mutations": [
+        {
+          "code": "steppedsinkhold-cavemut",
+          "comment": "Cave mutation",
+          "chance": 0.15,
+          "hexcolor": "#AAAA00",
+          "terrainYKeyPositions": [
+            0.399,
+            0.419,
+            0.427,
+            0.437,
+            0.457,
+            0.462,
+            0.484,
+            0.489,
+            0.513,
+            0.518,
+            0.525
+          ],
+          "terrainYKeyThresholds": [
+            1.0,
+            0.816,
+            0.035,
+            0.808,
+            0.816,
+            0.761,
+            0.76,
+            0.719,
+            0.718,
+            0.688,
+            0.0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "largeislands",
+      "comment": "lots of water, large island and a few tiny islands",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.271,
+        0.433,
+        0.455,
+        0.46,
+        0.801,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        0.767,
+        0.368,
+        0.288,
+        0.24,
+        0.078,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticflatlands",
+      "comment": "Very large scale flat lands",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.41,
+        0.518
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticmountains-ledged",
+      "comment": "Very large scale mountains with ledges",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.15,
+        0.15,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.396,
+        0.428,
+        0.433,
+        0.468,
+        0.475,
+        0.656,
+        0.661,
+        0.718,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.71,
+        0.65,
+        0.584,
+        0.557,
+        0.524,
+        0.342,
+        0.287,
+        0.29,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticmountains-quintupleledged",
+      "comment": "Very large scale mountains with ledges",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.15,
+        0.15,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.396,
+        0.428,
+        0.433,
+        0.468,
+        0.475,
+        0.513,
+        0.518,
+        0.586,
+        0.646,
+        0.651,
+        0.718,
+        0.797,
+        0.803,
+        0.882,
+        0.89,
+        0.963
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.71,
+        0.65,
+        0.584,
+        0.557,
+        0.524,
+        0.479,
+        0.41,
+        0.41,
+        0.362,
+        0.287,
+        0.29,
+        0.208,
+        0.127,
+        0.13,
+        0.055,
+        0.0
+      ]
+    },
+    {
+      "code": "islandchess",
+      "comment": "checkboard of land and water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "minTemp": -4,
+      "minRain": 120,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.1
+      ],
+      "terrainYKeyPositions": [
+        0.41,
+        0.445
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.0
+      ]
+    },
+    {
+      "code": "needledflatlands",
+      "comment": "Flat lands with very thin small hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.1,
+        0.5,
+        0.75
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.476,
+        0.49,
+        0.545,
+        0.559
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.261,
+        0.167,
+        0.0
+      ]
+    },
+    {
+      "code": "Realistic mountains",
+      "comment": "Very large scale mountains",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.405,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.593,
+        0.0
+      ]
+    },
+    {
+      "code": "siberiansinkholes",
+      "comment": "Siberian sink holes",
+      "hexcolor": "#AAAA00",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.335,
+        0.468,
+        0.525,
+        0.545
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.978,
+        0.692,
+        0.0
+      ]
+    },
+    {
+      "code": "shallowmillionstepmountains",
+      "comment": "More shallow Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.418,
+        0.449,
+        0.474,
+        0.502,
+        0.507,
+        0.526,
+        0.539,
+        0.556,
+        0.563,
+        0.583,
+        0.589,
+        0.605,
+        0.61,
+        0.623,
+        0.63,
+        0.647,
+        0.652,
+        0.669
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.493,
+        0.439,
+        0.43,
+        0.397,
+        0.395,
+        0.36,
+        0.359,
+        0.319,
+        0.314,
+        0.287,
+        0.284,
+        0.257,
+        0.255,
+        0.224,
+        0.22,
+        0.187,
+        0.0
+      ]
+    },
+    {
+      "code": "mediummillionstepmountains",
+      "comment": "More shallow Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.417,
+        0.458,
+        0.483,
+        0.514,
+        0.523,
+        0.542,
+        0.548,
+        0.59,
+        0.595,
+        0.617,
+        0.623,
+        0.639,
+        0.644,
+        0.657,
+        0.662,
+        0.686,
+        0.701,
+        0.711
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.487,
+        0.439,
+        0.441,
+        0.4,
+        0.401,
+        0.363,
+        0.359,
+        0.317,
+        0.314,
+        0.287,
+        0.284,
+        0.257,
+        0.255,
+        0.222,
+        0.218,
+        0.19,
+        0.0
+      ]
+    },
+    {
+      "code": "tallmillionstepmountains",
+      "comment": "Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.413,
+        0.498,
+        0.547,
+        0.552,
+        0.582,
+        0.592,
+        0.62,
+        0.63,
+        0.657,
+        0.665,
+        0.687,
+        0.692,
+        0.715,
+        0.722,
+        0.745,
+        0.752,
+        0.782,
+        0.843,
+        0.892
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.532,
+        0.53,
+        0.482,
+        0.48,
+        0.442,
+        0.442,
+        0.402,
+        0.402,
+        0.37,
+        0.37,
+        0.34,
+        0.34,
+        0.307,
+        0.303,
+        0.27,
+        0.27,
+        0.007,
+        0.0
+      ]
+    },
+    {
+      "code": "roughflatlands",
+      "comment": "Rough near sea level flat lands",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.438,
+        0.5,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.267,
+        0.0
+      ]
+    },
+    {
+      "code": "roughlabyrinth",
+      "comment": "Rough labyrinth lands",
+      "hexcolor": "#A9810F",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0.5
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.51
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0
+      ]
+    },
+    {
+      "code": "supersmoothills",
+      "comment": "Super Smooth hills",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0.4,
+        0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0
+      ]
+    },
+    {
+      "code": "largelake",
+      "comment": "Just water :P",
+      "hexcolor": "#0000FF",
+      "weight": 0.10869565217391304,
+      "minTemp": 0,
+      "maxTemp": 50,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.36,
+        0.4,
+        0.43
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.6,
+        0
+      ]
+    },
+    {
+      "code": "cold glaciers",
+      "comment": "",
+      "hexcolor": "#000099",
+      "weight": 0.10869565217391304,
+      "minTemp": -20,
+      "maxTemp": -19.5,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0.25,
+        0,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.426,
+        0.431,
+        0.588,
+        0.601,
+        0.643
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.957,
+        0.962,
+        0.022,
+        0.0
+      ]
+    },
+    {
+      "code": "cold mountain range",
+      "comment": "",
+      "hexcolor": "#000099",
+      "weight": 0.10869565217391304,
+      "minTemp": -20,
+      "maxTemp": -19.5,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.405,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.593,
+        0.0
+      ]
+    },
+    {
+      "code": "humongous mountain",
+      "comment": "humongous mountains with caverns in them",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        2,
+        1,
+        1,
+        0,
+        0.0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.33,
+        0.37,
+        0.41,
+        0.422,
+        0.5,
+        0.683,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.87,
+        0.842,
+        0.643,
+        0.988,
+        0.87,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.25,
+          "code": "humongous mountain, cavernless",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0.0,
+            0.423,
+            0.5,
+            0.683,
+            1.0
+          ],
+          "terrainYKeyThresholds": [
+            1.0,
+            1.0,
+            0.988,
+            0.87,
+            0.0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "hillplateu",
+      "comment": "high plateu with hills on top",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.25,
+        0.25,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.432,
+        0.611,
+        0.712,
+        0.735,
+        0.885
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.952,
+        0.66,
+        0.629,
+        0.0
+      ]
+    },
+    {
+      "code": "smallshallowislands",
+      "comment": "Small shallow islands with very small hills and lots of water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.36,
+        0.4,
+        0.43,
+        0.44,
+        0.497
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.8,
+        0.3,
+        0.17,
+        0.0
+      ]
+    },
+    {
+      "code": "shallowislands",
+      "comment": "Medium sized shallow islands with small bumps and lots of water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.25
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.36,
+        0.41,
+        0.43,
+        0.44,
+        0.471,
+        0.497,
+        0.54
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.805,
+        0.3,
+        0.192,
+        0.105,
+        0.016,
+        0.0
+      ]
+    },
+    {
+      "code": "cliffy rolling hills",
+      "comment": "cliffy rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0,
+        0,
+        0.5,
+        0.3,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.74,
+        0.75
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "superflatrarebumps",
+      "comment": "very flat lands with occasional bumps",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.425,
+        0.45,
+        0.56,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.3,
+        0
+      ]
+    },
+    {
+      "code": "veryflat",
+      "comment": "Very flat lands near sea level",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.01,
+        0.01
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.425,
+        0.45,
+        0.455
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.4,
+        0.0
+      ]
+    },
+    {
+      "code": "flatmanybumps",
+      "comment": "Flat land with many bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.59049,
+        0.531441,
+        0.4,
+        0.6,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.43,
+        0.55
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.3,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.4,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "veryflatmanybumps",
+      "comment": "Very flat land with many bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.59049,
+        0.531441,
+        0.4,
+        0.6,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.4,
+        0.43,
+        0.498
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.8,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.3,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.4,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "above sealevel flat grasslands",
+      "comment": "above sealevel flat grasslands with a single step",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        0.81,
+        0.729,
+        0.5,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.1,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.44,
+        0.5,
+        0.52,
+        0.6,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.5,
+        0.48,
+        0.15,
+        0.0
+      ]
+    },
+    {
+      "code": "rollinghills",
+      "comment": "near sealevel rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.2,
+        0.2,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.42,
+        0.5,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0.8,
+        0
+      ]
+    },
+    {
+      "code": "lowrollinghills",
+      "comment": "near sealevel low rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.2,
+        0.4,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.43,
+        0.55
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.15,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.41,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "cliffislands",
+      "comment": "Islands with tall cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        1,
+        0.2,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.41,
+        0.432,
+        0.44,
+        0.498,
+        0.547,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.432,
+        0.402,
+        0.393,
+        0.167,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.4,
+          "code": "sharp cliff islands",
+          "hexcolor": "#79E02E",
+          "terrainOctaves": [
+            0.9,
+            0.81,
+            0.729,
+            0.6561,
+            0.59049,
+            0.531441,
+            1,
+            0.3,
+            0.4
+          ]
+        }
+      ]
+    },
+    {
+      "code": "smallcliffislands",
+      "comment": "Islands with many small cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.4,
+        0.6,
+        0.5,
+        1,
+        0.3,
+        0.9
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2
+      ],
+      "terrainYKeyPositions": [
+        0.188,
+        0.355,
+        0.391,
+        0.427,
+        0.433,
+        0.46,
+        0.486,
+        0.542
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.9,
+        0.527,
+        0.398,
+        0.393,
+        0.167,
+        0.0
+      ]
+    },
+    {
+      "code": "bumplands",
+      "comment": "flat with small and big bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1.0,
+        0,
+        0.2,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.7,
+        0.75,
+        0.76
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.7,
+        0.5,
+        0.2,
+        0.02,
+        0
+      ]
+    },
+    {
+      "code": "roundclifflandshilly",
+      "comment": "round clifflands (more hilly, less easily traversable)",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        1.0,
+        0,
+        0.2,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.42,
+        0.43,
+        0.45,
+        0.7,
+        0.75,
+        0.76
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.9,
+        0.7,
+        0.5,
+        0.2,
+        0.02,
+        0
+      ]
+    },
+    {
+      "code": "sparsecliffyswamplands",
+      "comment": "Swamp lands with sparse short 2-stepped cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.1,
+        0.2,
+        0.3,
+        1.0,
+        0.4,
+        0.4,
+        0.5,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.154,
+        0.401,
+        0.43,
+        0.446,
+        0.465,
+        0.47,
+        0.488,
+        0.498,
+        0.521
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.99,
+        0.682,
+        0.303,
+        0.297,
+        0.225,
+        0.222,
+        0.17,
+        0.0
+      ]
+    },
+    {
+      "code": "densecliffyswamplands",
+      "comment": "Swamp lands with dense tall cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.1,
+        0.2,
+        0.3,
+        1.0,
+        0.4,
+        0.4,
+        0.5,
+        0.35
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.42,
+        0.43,
+        0.45,
+        0.7,
+        0.75
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.9,
+        0.7,
+        0.4,
+        0.1,
+        0
+      ]
+    },
+    {
+      "code": "deep water step mountains",
+      "comment": "Step mountains in deep water",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.45,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.65,
+        0.39,
+        0.2,
+        0.2,
+        0.05,
+        0.0
+      ]
+    },
+    {
+      "code": "step mountains",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 0.41, 0.30, 0.20, 0.08, 0.0]
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7,
+        0.8,
+        0.84,
+        0.9
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.41,
+        0.3,
+        0.3,
+        0.2,
+        0.2,
+        0.08,
+        0.08,
+        0.0
+      ]
+    },
+    {
+      "code": "flathillvalley",
+      "comment": "Flat lands with occasional hills and valleys",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0.3,
+        0,
+        0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.3,
+        0.3,
+        0.3,
+        0.3,
+        0.3,
+        0.2,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.443,
+        0.463,
+        0.508,
+        0.548,
+        0.556,
+        0.598,
+        0.699,
+        0.8
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.573,
+        0.373,
+        0.3,
+        0.272,
+        0.26,
+        0.11,
+        0.0
+      ]
+    },
+    {
+      "code": "hillsflatsandislands",
+      "comment": "A colorful mix of flats, hillgroups and islands",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        1,
+        1,
+        1,
+        0.5,
+        0.2,
+        0.4,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.397,
+        0.415,
+        0.438,
+        0.459,
+        0.548,
+        0.602,
+        0.684,
+        0.711,
+        0.752
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.77,
+        0.517,
+        0.287,
+        0.197,
+        0.117,
+        0.047,
+        0.047,
+        0.0
+      ]
+    },
+    {
+      "code": "smallsealevelplateus",
+      "comment": "Small many near sea level plateus",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.25,
+        0.3,
+        1,
+        1,
+        0.7,
+        0.15
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.43,
+        0.45,
+        0.455,
+        0.495,
+        0.505,
+        0.525,
+        0.535
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        1,
+        0.63,
+        0.27,
+        0.27,
+        0.09,
+        0.09,
+        0
+      ]
+    },
+    {
+      "code": "mediumseapillars",
+      "comment": "medium stepped pillars in the sea",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        1,
+        0.7,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.15
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.365,
+        0.43,
+        0.443,
+        0.51,
+        0.52,
+        0.56,
+        0.57,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.4,
+        0.227,
+        0.223,
+        0.17,
+        0.168,
+        0.13,
+        0.0
+      ]
+    },
+    {
+      "code": "mediumlandpillars",
+      "comment": "medium stepped pillars on flat land",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.4,
+        1,
+        0.7,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.435,
+        0.45,
+        0.5,
+        0.54,
+        0.55,
+        0.59,
+        0.6,
+        0.64,
+        0.66
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.22,
+        0.21,
+        0.18,
+        0.17,
+        0.14,
+        0.13,
+        0
+      ]
+    },
+    {
+      "code": "marsh",
+      "comment": "very flat lands with small rough hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "bumpy marsh",
+      "comment": "Near sea lavel lakes with small round hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "flatmarsh",
+      "comment": "very flat lands with rare small bumps",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.35,
+        0.15,
+        0
+      ]
+    },
+    {
+      "code": "deathmarsh",
+      "comment": "some strange pool here",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.08,
+        0.4,
+        0.425,
+        0.43,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.66,
+        0.55,
+        0.7,
+        0.55,
+        0.35,
+        0.15,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.5,
+          "code": "deathmarsh hill",
+          "hexcolor": "#79E02E",
+          "terrainOctaves": [
+            0,
+            0,
+            0,
+            0,
+            0.2,
+            0.2,
+            1,
+            0.5,
+            0
+          ],
+          "terrainOctaveThresholds": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.4,
+            0.1,
+            0
+          ],
+          "terrainYKeyPositions": [
+            0,
+            0.08,
+            0.4,
+            0.42,
+            0.43,
+            0.44,
+            0.51,
+            0.7
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            0.66,
+            0.55,
+            0.7,
+            0.55,
+            0.5,
+            0.4,
+            0
+          ]
+        }
+      ]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2,40 +2,2379 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains 6-tier hybrid crisp",
-      "comment": "Octave 2 & 7 halved; crisp plateaus across 6 tiers",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.03, 0.00]
-    },
-    {
-      "code": "step mountains 6-tier hybrid top-lock",
-      "comment": "Octave 2 & 7 halved; crisp tiers with strong attraction to top bands",
-      "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
-      "terrainYKeyThresholds": [0.12, 0.05, 0.04, 0.04, 0.04, 0.10, 0.00]
-    },
-    {
       "code": "step mountains custom",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.6, 0.62, 0.68, 0.7, 0.8, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 0.41, 0.3, 0.30, 0.2, 0.20, 0.08, 0.08, 0.0]
+      "weight": 80,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.365,
+        0.6561,
+        0,
+        0.531441,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7,
+        0.8,
+        0.84,
+        0.9
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.41,
+        0.3,
+        0.3,
+        0.2,
+        0.2,
+        0.08,
+        0.08,
+        0.0
+      ]
     },
     {
-      "code": "step mountains custom 6",
+      "code": "steppedsinkholes",
+      "comment": "Stepped sink holes",
+      "hexcolor": "#AAAA00",
+      "weight": 15,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.431,
+        0.436,
+        0.457,
+        0.462,
+        0.484,
+        0.489,
+        0.513,
+        0.518,
+        0.525
+      ],
+      "terrainYKeyThresholds": [
+        0.999,
+        0.814,
+        0.816,
+        0.761,
+        0.76,
+        0.719,
+        0.718,
+        0.688,
+        0.0
+      ],
+      "mutations": [
+        {
+          "code": "steppedsinkhold-cavemut",
+          "comment": "Cave mutation",
+          "chance": 0.15,
+          "hexcolor": "#AAAA00",
+          "terrainYKeyPositions": [
+            0.399,
+            0.419,
+            0.427,
+            0.437,
+            0.457,
+            0.462,
+            0.484,
+            0.489,
+            0.513,
+            0.518,
+            0.525
+          ],
+          "terrainYKeyThresholds": [
+            1.0,
+            0.816,
+            0.035,
+            0.808,
+            0.816,
+            0.761,
+            0.76,
+            0.719,
+            0.718,
+            0.688,
+            0.0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "largeislands",
+      "comment": "lots of water, large island and a few tiny islands",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.271,
+        0.433,
+        0.455,
+        0.46,
+        0.801,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        0.767,
+        0.368,
+        0.288,
+        0.24,
+        0.078,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticflatlands",
+      "comment": "Very large scale flat lands",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.41,
+        0.518
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticmountains-ledged",
+      "comment": "Very large scale mountains with ledges",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.15,
+        0.15,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.396,
+        0.428,
+        0.433,
+        0.468,
+        0.475,
+        0.656,
+        0.661,
+        0.718,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.71,
+        0.65,
+        0.584,
+        0.557,
+        0.524,
+        0.342,
+        0.287,
+        0.29,
+        0.0
+      ]
+    },
+    {
+      "code": "realisticmountains-quintupleledged",
+      "comment": "Very large scale mountains with ledges",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.15,
+        0.15,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.396,
+        0.428,
+        0.433,
+        0.468,
+        0.475,
+        0.513,
+        0.518,
+        0.586,
+        0.646,
+        0.651,
+        0.718,
+        0.797,
+        0.803,
+        0.882,
+        0.89,
+        0.963
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.71,
+        0.65,
+        0.584,
+        0.557,
+        0.524,
+        0.479,
+        0.41,
+        0.41,
+        0.362,
+        0.287,
+        0.29,
+        0.208,
+        0.127,
+        0.13,
+        0.055,
+        0.0
+      ]
+    },
+    {
+      "code": "islandchess",
+      "comment": "checkboard of land and water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "minTemp": -4,
+      "minRain": 120,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.1
+      ],
+      "terrainYKeyPositions": [
+        0.41,
+        0.445
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.0
+      ]
+    },
+    {
+      "code": "needledflatlands",
+      "comment": "Flat lands with very thin small hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.1,
+        0.5,
+        0.75
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.476,
+        0.49,
+        0.545,
+        0.559
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.261,
+        0.167,
+        0.0
+      ]
+    },
+    {
+      "code": "Realistic mountains",
+      "comment": "Very large scale mountains",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.405,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.593,
+        0.0
+      ]
+    },
+    {
+      "code": "siberiansinkholes",
+      "comment": "Siberian sink holes",
+      "hexcolor": "#AAAA00",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.335,
+        0.468,
+        0.525,
+        0.545
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.978,
+        0.692,
+        0.0
+      ]
+    },
+    {
+      "code": "shallowmillionstepmountains",
+      "comment": "More shallow Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.418,
+        0.449,
+        0.474,
+        0.502,
+        0.507,
+        0.526,
+        0.539,
+        0.556,
+        0.563,
+        0.583,
+        0.589,
+        0.605,
+        0.61,
+        0.623,
+        0.63,
+        0.647,
+        0.652,
+        0.669
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.493,
+        0.439,
+        0.43,
+        0.397,
+        0.395,
+        0.36,
+        0.359,
+        0.319,
+        0.314,
+        0.287,
+        0.284,
+        0.257,
+        0.255,
+        0.224,
+        0.22,
+        0.187,
+        0.0
+      ]
+    },
+    {
+      "code": "mediummillionstepmountains",
+      "comment": "More shallow Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.417,
+        0.458,
+        0.483,
+        0.514,
+        0.523,
+        0.542,
+        0.548,
+        0.59,
+        0.595,
+        0.617,
+        0.623,
+        0.639,
+        0.644,
+        0.657,
+        0.662,
+        0.686,
+        0.701,
+        0.711
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.487,
+        0.439,
+        0.441,
+        0.4,
+        0.401,
+        0.363,
+        0.359,
+        0.317,
+        0.314,
+        0.287,
+        0.284,
+        0.257,
+        0.255,
+        0.222,
+        0.218,
+        0.19,
+        0.0
+      ]
+    },
+    {
+      "code": "tallmillionstepmountains",
+      "comment": "Million steps mountain",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.413,
+        0.498,
+        0.547,
+        0.552,
+        0.582,
+        0.592,
+        0.62,
+        0.63,
+        0.657,
+        0.665,
+        0.687,
+        0.692,
+        0.715,
+        0.722,
+        0.745,
+        0.752,
+        0.782,
+        0.843,
+        0.892
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.532,
+        0.53,
+        0.482,
+        0.48,
+        0.442,
+        0.442,
+        0.402,
+        0.402,
+        0.37,
+        0.37,
+        0.34,
+        0.34,
+        0.307,
+        0.303,
+        0.27,
+        0.27,
+        0.007,
+        0.0
+      ]
+    },
+    {
+      "code": "roughflatlands",
+      "comment": "Rough near sea level flat lands",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0.5,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.438,
+        0.5,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.267,
+        0.0
+      ]
+    },
+    {
+      "code": "roughlabyrinth",
+      "comment": "Rough labyrinth lands",
+      "hexcolor": "#A9810F",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        0.5
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.51
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0
+      ]
+    },
+    {
+      "code": "supersmoothills",
+      "comment": "Super Smooth hills",
+      "hexcolor": "#333333",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0.4,
+        0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0
+      ]
+    },
+    {
+      "code": "largelake",
+      "comment": "Just water :P",
+      "hexcolor": "#0000FF",
+      "weight": 0.10869565217391304,
+      "minTemp": 0,
+      "maxTemp": 50,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.36,
+        0.4,
+        0.43
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.6,
+        0
+      ]
+    },
+    {
+      "code": "cold glaciers",
+      "comment": "",
+      "hexcolor": "#000099",
+      "weight": 0.10869565217391304,
+      "minTemp": -20,
+      "maxTemp": -19.5,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        1,
+        1,
+        1,
+        0.25,
+        0,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.426,
+        0.431,
+        0.588,
+        0.601,
+        0.643
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.957,
+        0.962,
+        0.022,
+        0.0
+      ]
+    },
+    {
+      "code": "cold mountain range",
+      "comment": "",
+      "hexcolor": "#000099",
+      "weight": 0.10869565217391304,
+      "minTemp": -20,
+      "maxTemp": -19.5,
+      "useClimateMap": true,
+      "terrainOctaves": [
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.1,
+        0.1,
+        0.1,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.03,
+        0.03,
+        0.05
+      ],
+      "terrainYKeyPositions": [
+        0.345,
+        0.405,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.593,
+        0.0
+      ]
+    },
+    {
+      "code": "humongous mountain",
+      "comment": "humongous mountains with caverns in them",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        2,
+        1,
+        1,
+        0,
+        0.0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.33,
+        0.37,
+        0.41,
+        0.422,
+        0.5,
+        0.683,
+        1.0
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.87,
+        0.842,
+        0.643,
+        0.988,
+        0.87,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.25,
+          "code": "humongous mountain, cavernless",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0.0,
+            0.423,
+            0.5,
+            0.683,
+            1.0
+          ],
+          "terrainYKeyThresholds": [
+            1.0,
+            1.0,
+            0.988,
+            0.87,
+            0.0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "hillplateu",
+      "comment": "high plateu with hills on top",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        1,
+        1,
+        1,
+        1,
+        0,
+        0.25,
+        0.25,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.432,
+        0.611,
+        0.712,
+        0.735,
+        0.885
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.952,
+        0.66,
+        0.629,
+        0.0
+      ]
+    },
+    {
+      "code": "smallshallowislands",
+      "comment": "Small shallow islands with very small hills and lots of water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.36,
+        0.4,
+        0.43,
+        0.44,
+        0.497
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.8,
+        0.3,
+        0.17,
+        0.0
+      ]
+    },
+    {
+      "code": "shallowislands",
+      "comment": "Medium sized shallow islands with small bumps and lots of water",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        1,
+        0.1,
+        0.25,
+        0.3,
+        0.6
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.25
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.36,
+        0.41,
+        0.43,
+        0.44,
+        0.471,
+        0.497,
+        0.54
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.805,
+        0.3,
+        0.192,
+        0.105,
+        0.016,
+        0.0
+      ]
+    },
+    {
+      "code": "cliffy rolling hills",
+      "comment": "cliffy rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0,
+        0,
+        0.5,
+        0.3,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.74,
+        0.75
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "superflatrarebumps",
+      "comment": "very flat lands with occasional bumps",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.425,
+        0.45,
+        0.56,
+        0.6
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.3,
+        0
+      ]
+    },
+    {
+      "code": "veryflat",
+      "comment": "Very flat lands near sea level",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.2,
+        0.3,
+        0,
+        1,
+        0.01,
+        0.01
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.425,
+        0.45,
+        0.455
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.4,
+        0.0
+      ]
+    },
+    {
+      "code": "flatmanybumps",
+      "comment": "Flat land with many bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.59049,
+        0.531441,
+        0.4,
+        0.6,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.43,
+        0.55
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.3,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.4,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "veryflatmanybumps",
+      "comment": "Very flat land with many bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.59049,
+        0.531441,
+        0.4,
+        0.6,
+        0.25
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.4,
+        0.43,
+        0.498
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.8,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.3,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.4,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "above sealevel flat grasslands",
+      "comment": "above sealevel flat grasslands with a single step",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        1,
+        0.81,
+        0.729,
+        0.5,
+        0.3,
+        0,
+        1,
+        0.25,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.1,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.44,
+        0.5,
+        0.52,
+        0.6,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.5,
+        0.48,
+        0.15,
+        0.0
+      ]
+    },
+    {
+      "code": "rollinghills",
+      "comment": "near sealevel rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.2,
+        0.2,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.42,
+        0.5,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0.8,
+        0
+      ]
+    },
+    {
+      "code": "lowrollinghills",
+      "comment": "near sealevel low rolling hills",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.2,
+        0.4,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.43,
+        0.55
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.8,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.15,
+          "code": "rollinghillssubstract",
+          "hexcolor": "#79E02E",
+          "terrainYKeyPositions": [
+            0,
+            0.41,
+            0.43,
+            0.45
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            1,
+            0.8,
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "code": "cliffislands",
+      "comment": "Islands with tall cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0.9,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        1,
+        0.2,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.41,
+        0.432,
+        0.44,
+        0.498,
+        0.547,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.432,
+        0.402,
+        0.393,
+        0.167,
+        0.0
+      ],
+      "mutations": [
+        {
+          "chance": 0.4,
+          "code": "sharp cliff islands",
+          "hexcolor": "#79E02E",
+          "terrainOctaves": [
+            0.9,
+            0.81,
+            0.729,
+            0.6561,
+            0.59049,
+            0.531441,
+            1,
+            0.3,
+            0.4
+          ]
+        }
+      ]
+    },
+    {
+      "code": "smallcliffislands",
+      "comment": "Islands with many small cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.4,
+        0.6,
+        0.5,
+        1,
+        0.3,
+        0.9
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2,
+        0.2
+      ],
+      "terrainYKeyPositions": [
+        0.188,
+        0.355,
+        0.391,
+        0.427,
+        0.433,
+        0.46,
+        0.486,
+        0.542
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.9,
+        0.527,
+        0.398,
+        0.393,
+        0.167,
+        0.0
+      ]
+    },
+    {
+      "code": "bumplands",
+      "comment": "flat with small and big bumps",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        1.0,
+        0,
+        0.2,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.45,
+        0.7,
+        0.75,
+        0.76
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.7,
+        0.5,
+        0.2,
+        0.02,
+        0
+      ]
+    },
+    {
+      "code": "roundclifflandshilly",
+      "comment": "round clifflands (more hilly, less easily traversable)",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        1.0,
+        0,
+        0.2,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.42,
+        0.43,
+        0.45,
+        0.7,
+        0.75,
+        0.76
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.9,
+        0.7,
+        0.5,
+        0.2,
+        0.02,
+        0
+      ]
+    },
+    {
+      "code": "sparsecliffyswamplands",
+      "comment": "Swamp lands with sparse short 2-stepped cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.1,
+        0.2,
+        0.3,
+        1.0,
+        0.4,
+        0.4,
+        0.5,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.154,
+        0.401,
+        0.43,
+        0.446,
+        0.465,
+        0.47,
+        0.488,
+        0.498,
+        0.521
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.99,
+        0.682,
+        0.303,
+        0.297,
+        0.225,
+        0.222,
+        0.17,
+        0.0
+      ]
+    },
+    {
+      "code": "densecliffyswamplands",
+      "comment": "Swamp lands with dense tall cliffs",
+      "hexcolor": "#5BC184",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.1,
+        0.2,
+        0.3,
+        1.0,
+        0.4,
+        0.4,
+        0.5,
+        0.35
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0.3,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.42,
+        0.43,
+        0.45,
+        0.7,
+        0.75
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.9,
+        0.7,
+        0.4,
+        0.1,
+        0
+      ]
+    },
+    {
+      "code": "deep water step mountains",
+      "comment": "Step mountains in deep water",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0.59049,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.45,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.65,
+        0.39,
+        0.2,
+        0.2,
+        0.05,
+        0.0
+      ]
+    },
+    {
+      "code": "step mountains",
       "comment": "Raised terrain with mountains that have several steps in them",
       "hexcolor": "#84A878",
-      "weight": 1,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
-      "terrainYKeyPositions": [0, 0.43, 0.5, 0.62, 0.7, 0.84, 0.9],
-      "terrainYKeyThresholds": [1, 1, 0.41, 0.30, 0.20, 0.08, 0.0]
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        0.729,
+        0.6561,
+        0,
+        0.531441,
+        0.4,
+        0.2,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.43,
+        0.5,
+        0.6,
+        0.62,
+        0.68,
+        0.7,
+        0.8,
+        0.84,
+        0.9
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.41,
+        0.3,
+        0.3,
+        0.2,
+        0.2,
+        0.08,
+        0.08,
+        0.0
+      ]
+    },
+    {
+      "code": "flathillvalley",
+      "comment": "Flat lands with occasional hills and valleys",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0.3,
+        0,
+        0,
+        0.1
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0.3,
+        0.3,
+        0.3,
+        0.3,
+        0.3,
+        0.2,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.443,
+        0.463,
+        0.508,
+        0.548,
+        0.556,
+        0.598,
+        0.699,
+        0.8
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.573,
+        0.373,
+        0.3,
+        0.272,
+        0.26,
+        0.11,
+        0.0
+      ]
+    },
+    {
+      "code": "hillsflatsandislands",
+      "comment": "A colorful mix of flats, hillgroups and islands",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0.81,
+        1,
+        1,
+        1,
+        0.5,
+        0.2,
+        0.4,
+        0.3
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.5,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0.397,
+        0.415,
+        0.438,
+        0.459,
+        0.548,
+        0.602,
+        0.684,
+        0.711,
+        0.752
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        0.77,
+        0.517,
+        0.287,
+        0.197,
+        0.117,
+        0.047,
+        0.047,
+        0.0
+      ]
+    },
+    {
+      "code": "smallsealevelplateus",
+      "comment": "Small many near sea level plateus",
+      "hexcolor": "#84A878",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0.25,
+        0.3,
+        1,
+        1,
+        0.7,
+        0.15
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.43,
+        0.45,
+        0.455,
+        0.495,
+        0.505,
+        0.525,
+        0.535
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        1,
+        0.63,
+        0.27,
+        0.27,
+        0.09,
+        0.09,
+        0
+      ]
+    },
+    {
+      "code": "mediumseapillars",
+      "comment": "medium stepped pillars in the sea",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        1,
+        0.7,
+        0.2
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.15
+      ],
+      "terrainYKeyPositions": [
+        0.0,
+        0.365,
+        0.43,
+        0.443,
+        0.51,
+        0.52,
+        0.56,
+        0.57,
+        0.65
+      ],
+      "terrainYKeyThresholds": [
+        1.0,
+        1.0,
+        0.4,
+        0.227,
+        0.223,
+        0.17,
+        0.168,
+        0.13,
+        0.0
+      ]
+    },
+    {
+      "code": "mediumlandpillars",
+      "comment": "medium stepped pillars on flat land",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.4,
+        1,
+        0.7,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.3
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.435,
+        0.45,
+        0.5,
+        0.54,
+        0.55,
+        0.59,
+        0.6,
+        0.64,
+        0.66
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.22,
+        0.21,
+        0.18,
+        0.17,
+        0.14,
+        0.13,
+        0
+      ]
+    },
+    {
+      "code": "marsh",
+      "comment": "very flat lands with small rough hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "bumpy marsh",
+      "comment": "Near sea lavel lakes with small round hills",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.4,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.4,
+        0.2,
+        0
+      ]
+    },
+    {
+      "code": "flatmarsh",
+      "comment": "very flat lands with rare small bumps",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.41,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        1,
+        0.35,
+        0.15,
+        0
+      ]
+    },
+    {
+      "code": "deathmarsh",
+      "comment": "some strange pool here",
+      "hexcolor": "#79E02E",
+      "weight": 0.10869565217391304,
+      "terrainOctaves": [
+        0,
+        0,
+        0,
+        0,
+        0.2,
+        0.2,
+        1,
+        0.5,
+        0
+      ],
+      "terrainOctaveThresholds": [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.4,
+        0.1,
+        0
+      ],
+      "terrainYKeyPositions": [
+        0,
+        0.08,
+        0.4,
+        0.425,
+        0.43,
+        0.44,
+        0.51,
+        0.7
+      ],
+      "terrainYKeyThresholds": [
+        1,
+        0.66,
+        0.55,
+        0.7,
+        0.55,
+        0.35,
+        0.15,
+        0
+      ],
+      "mutations": [
+        {
+          "chance": 0.5,
+          "code": "deathmarsh hill",
+          "hexcolor": "#79E02E",
+          "terrainOctaves": [
+            0,
+            0,
+            0,
+            0,
+            0.2,
+            0.2,
+            1,
+            0.5,
+            0
+          ],
+          "terrainOctaveThresholds": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.4,
+            0.1,
+            0
+          ],
+          "terrainYKeyPositions": [
+            0,
+            0.08,
+            0.4,
+            0.42,
+            0.43,
+            0.44,
+            0.51,
+            0.7
+          ],
+          "terrainYKeyThresholds": [
+            1,
+            0.66,
+            0.55,
+            0.7,
+            0.55,
+            0.5,
+            0.4,
+            0
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Restore all vanilla landforms to SelectedLandforms
- Give custom step mountains 80% spawn weight
- Allocate 15% to stepped sinkholes and 5% shared among other vanilla landforms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6899ff4017d08323a066f5da5bc7f585