### PR TITLE
Update custom landform to crisp variant

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -2,45 +2,12 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains custom",
-      "comment": "Raised terrain with mountains that have several steps in them",
+      "code": "step mountains custom 6 (crisp)",
       "hexcolor": "#84A878",
       "weight": 80,
-      "terrainOctaves": [
-        0,
-        0.81,
-        0.365,
-        0.6561,
-        0,
-        0.531441,
-        0.4,
-        0.1,
-        0
-      ],
-      "terrainYKeyPositions": [
-        0,
-        0.43,
-        0.5,
-        0.6,
-        0.62,
-        0.68,
-        0.7,
-        0.8,
-        0.84,
-        0.9
-      ],
-      "terrainYKeyThresholds": [
-        1,
-        1,
-        0.41,
-        0.3,
-        0.3,
-        0.2,
-        0.2,
-        0.08,
-        0.08,
-        0.0
-      ]
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.03, 0.04, 0.03, 0.04, 0.02, 0.00]
     },
     {
       "code": "steppedsinkholes",

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2,45 +2,12 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains custom",
-      "comment": "Raised terrain with mountains that have several steps in them",
+      "code": "step mountains custom 6 (crisp)",
       "hexcolor": "#84A878",
       "weight": 80,
-      "terrainOctaves": [
-        0,
-        0.81,
-        0.365,
-        0.6561,
-        0,
-        0.531441,
-        0.4,
-        0.1,
-        0
-      ],
-      "terrainYKeyPositions": [
-        0,
-        0.43,
-        0.5,
-        0.6,
-        0.62,
-        0.68,
-        0.7,
-        0.8,
-        0.84,
-        0.9
-      ],
-      "terrainYKeyThresholds": [
-        1,
-        1,
-        0.41,
-        0.3,
-        0.3,
-        0.2,
-        0.2,
-        0.08,
-        0.08,
-        0.0
-      ]
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.03, 0.04, 0.03, 0.04, 0.02, 0.00]
     },
     {
       "code": "steppedsinkholes",

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2,45 +2,12 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step mountains custom",
-      "comment": "Raised terrain with mountains that have several steps in them",
+      "code": "step mountains custom 6 (crisp)",
       "hexcolor": "#84A878",
       "weight": 80,
-      "terrainOctaves": [
-        0,
-        0.81,
-        0.365,
-        0.6561,
-        0,
-        0.531441,
-        0.4,
-        0.1,
-        0
-      ],
-      "terrainYKeyPositions": [
-        0,
-        0.43,
-        0.5,
-        0.6,
-        0.62,
-        0.68,
-        0.7,
-        0.8,
-        0.84,
-        0.9
-      ],
-      "terrainYKeyThresholds": [
-        1,
-        1,
-        0.41,
-        0.3,
-        0.3,
-        0.2,
-        0.2,
-        0.08,
-        0.08,
-        0.0
-      ]
+      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "terrainYKeyPositions": [0.00, 0.43, 0.50, 0.62, 0.70, 0.84, 0.90],
+      "terrainYKeyThresholds": [0.12, 0.03, 0.04, 0.03, 0.04, 0.02, 0.00]
     },
     {
       "code": "steppedsinkholes",


### PR DESCRIPTION
## Summary
- replace `step mountains custom` with `step mountains custom 6 (crisp)` across landform configs
- retain weight at 80 and update terrain keys

## Testing
- `python -m json.tool WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json`
- `python -m json.tool WorldgenMod/SelectedLandforms/data/landforms.json`
- `python -m json.tool WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json`


------
https://chatgpt.com/codex/tasks/task_b_689a06e2c8408323a386cc3340d6b4f3