### PR TITLE
Refresh custom landforms and rebalance generation

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -2,54 +2,52 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step_mountains_6tier_o2o7half_wide",
-      "comment": "Six flat, wider plateaus with sheer cliffs (octave 2 & 7 halved)",
+      "code": "step_mountains_6tier_o2o7half_wide_v4",
       "hexcolor": "#84A878",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "weight": 3.392857,
+      "terrainOctaves": [0, 0.81, 0.365, 0.50, 0.00, 0.35, 0.22, 0.06, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.62, 0.58, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,   0.560, 0.569,
-        0.675, 0.684,   0.790, 0.799,
-        0.895, 0.904,   0.955, 0.964
+        0.430, 0.450,   0.570, 0.582,
+        0.690, 0.700,   0.800, 0.806,
+        0.895, 0.898,   0.952, 0.954
       ],
       "terrainYKeyThresholds": [
-        1.00, 0.70,   0.69, 0.52,
-        0.51, 0.38,   0.37, 0.26,
-        0.25, 0.14,   0.13, 0.00
+        1.00, 0.70,   0.695, 0.52,
+        0.515, 0.40,  0.395, 0.28,
+        0.275, 0.18,  0.175, 0.00
       ]
     },
     {
-      "code": "steppedsinkholes_with_risers_o2o7half_wide",
-      "comment": "Stepped pits AND mesas; wider shelves, sheer walls (octave 2 & 7 halved)",
+      "code": "steppedsinkholes_risers_o2o7half_wide_v4",
       "hexcolor": "#AAAA00",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0, 1.00, 1.00, 0.425, 0],
-      "terrainOctaveThresholds": [0,0,0,0,0,0.60,0.55,0,0],
+      "weight": 50.892857,
+      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0.00, 1.00, 0.95, 0.425, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.58, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,  0.459, 0.468,  0.489, 0.498,  0.519, 0.528,
-        0.548, 0.557,  0.577, 0.586,  0.607, 0.616,  0.636, 0.645
+        0.430, 0.448,  0.468, 0.478,  0.496, 0.506,  0.524, 0.532,
+        0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640,  0.662, 0.664
       ],
       "terrainYKeyThresholds": [
-        0.98, 0.72,  0.71, 0.56,  0.55, 0.43,  0.42, 0.33,
-        0.32, 0.24,  0.23, 0.18,  0.17, 0.12,  0.11, 0.00
+        0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
+        0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.11,  0.105, 0.00
       ]
     },
     {
-      "code": "canyons_mesas_o2o7half_wide",
-      "comment": "Broad mesas with deep canyons; wider shelves, sheer walls (octave 2 & 7 halved)",
+      "code": "canyons_mesas_o2o7half_wide_v4",
       "hexcolor": "#C28E52",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.82, 0.30, 0.48, 0, 0.35, 0.30, 0.04, 0],
-      "terrainOctaveThresholds": [0,0,0,0,0,0.60,0.55,0,0],
+      "weight": 40.714286,
+      "terrainOctaves": [0, 0.82, 0.30, 0.45, 0.00, 0.32, 0.26, 0.04, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.56, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,   0.570, 0.579,
-        0.700, 0.709,   0.840, 0.849,
-        0.960, 0.969
+        0.430, 0.450,   0.575, 0.588,
+        0.700, 0.710,   0.840, 0.846,
+        0.960, 0.962
       ],
       "terrainYKeyThresholds": [
-        1.00, 0.72,   0.71, 0.52,
-        0.51, 0.36,   0.35, 0.20,
-        0.19, 0.00
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.36,  0.355, 0.20,
+        0.195, 0.00
       ]
     },
     {

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2,54 +2,52 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step_mountains_6tier_o2o7half_wide",
-      "comment": "Six flat, wider plateaus with sheer cliffs (octave 2 & 7 halved)",
+      "code": "step_mountains_6tier_o2o7half_wide_v4",
       "hexcolor": "#84A878",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "weight": 3.392857,
+      "terrainOctaves": [0, 0.81, 0.365, 0.50, 0.00, 0.35, 0.22, 0.06, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.62, 0.58, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,   0.560, 0.569,
-        0.675, 0.684,   0.790, 0.799,
-        0.895, 0.904,   0.955, 0.964
+        0.430, 0.450,   0.570, 0.582,
+        0.690, 0.700,   0.800, 0.806,
+        0.895, 0.898,   0.952, 0.954
       ],
       "terrainYKeyThresholds": [
-        1.00, 0.70,   0.69, 0.52,
-        0.51, 0.38,   0.37, 0.26,
-        0.25, 0.14,   0.13, 0.00
+        1.00, 0.70,   0.695, 0.52,
+        0.515, 0.40,  0.395, 0.28,
+        0.275, 0.18,  0.175, 0.00
       ]
     },
     {
-      "code": "steppedsinkholes_with_risers_o2o7half_wide",
-      "comment": "Stepped pits AND mesas; wider shelves, sheer walls (octave 2 & 7 halved)",
+      "code": "steppedsinkholes_risers_o2o7half_wide_v4",
       "hexcolor": "#AAAA00",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0, 1.00, 1.00, 0.425, 0],
-      "terrainOctaveThresholds": [0,0,0,0,0,0.60,0.55,0,0],
+      "weight": 50.892857,
+      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0.00, 1.00, 0.95, 0.425, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.58, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,  0.459, 0.468,  0.489, 0.498,  0.519, 0.528,
-        0.548, 0.557,  0.577, 0.586,  0.607, 0.616,  0.636, 0.645
+        0.430, 0.448,  0.468, 0.478,  0.496, 0.506,  0.524, 0.532,
+        0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640,  0.662, 0.664
       ],
       "terrainYKeyThresholds": [
-        0.98, 0.72,  0.71, 0.56,  0.55, 0.43,  0.42, 0.33,
-        0.32, 0.24,  0.23, 0.18,  0.17, 0.12,  0.11, 0.00
+        0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
+        0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.11,  0.105, 0.00
       ]
     },
     {
-      "code": "canyons_mesas_o2o7half_wide",
-      "comment": "Broad mesas with deep canyons; wider shelves, sheer walls (octave 2 & 7 halved)",
+      "code": "canyons_mesas_o2o7half_wide_v4",
       "hexcolor": "#C28E52",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.82, 0.30, 0.48, 0, 0.35, 0.30, 0.04, 0],
-      "terrainOctaveThresholds": [0,0,0,0,0,0.60,0.55,0,0],
+      "weight": 40.714286,
+      "terrainOctaves": [0, 0.82, 0.30, 0.45, 0.00, 0.32, 0.26, 0.04, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.56, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,   0.570, 0.579,
-        0.700, 0.709,   0.840, 0.849,
-        0.960, 0.969
+        0.430, 0.450,   0.575, 0.588,
+        0.700, 0.710,   0.840, 0.846,
+        0.960, 0.962
       ],
       "terrainYKeyThresholds": [
-        1.00, 0.72,   0.71, 0.52,
-        0.51, 0.36,   0.35, 0.20,
-        0.19, 0.00
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.36,  0.355, 0.20,
+        0.195, 0.00
       ]
     },
     {

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2,54 +2,52 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step_mountains_6tier_o2o7half_wide",
-      "comment": "Six flat, wider plateaus with sheer cliffs (octave 2 & 7 halved)",
+      "code": "step_mountains_6tier_o2o7half_wide_v4",
       "hexcolor": "#84A878",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.81, 0.365, 0.6561, 0, 0.531441, 0.4, 0.10, 0],
+      "weight": 3.392857,
+      "terrainOctaves": [0, 0.81, 0.365, 0.50, 0.00, 0.35, 0.22, 0.06, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.62, 0.58, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,   0.560, 0.569,
-        0.675, 0.684,   0.790, 0.799,
-        0.895, 0.904,   0.955, 0.964
+        0.430, 0.450,   0.570, 0.582,
+        0.690, 0.700,   0.800, 0.806,
+        0.895, 0.898,   0.952, 0.954
       ],
       "terrainYKeyThresholds": [
-        1.00, 0.70,   0.69, 0.52,
-        0.51, 0.38,   0.37, 0.26,
-        0.25, 0.14,   0.13, 0.00
+        1.00, 0.70,   0.695, 0.52,
+        0.515, 0.40,  0.395, 0.28,
+        0.275, 0.18,  0.175, 0.00
       ]
     },
     {
-      "code": "steppedsinkholes_with_risers_o2o7half_wide",
-      "comment": "Stepped pits AND mesas; wider shelves, sheer walls (octave 2 & 7 halved)",
+      "code": "steppedsinkholes_risers_o2o7half_wide_v4",
       "hexcolor": "#AAAA00",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0, 1.00, 1.00, 0.425, 0],
-      "terrainOctaveThresholds": [0,0,0,0,0,0.60,0.55,0,0],
+      "weight": 50.892857,
+      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0.00, 1.00, 0.95, 0.425, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.58, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,  0.459, 0.468,  0.489, 0.498,  0.519, 0.528,
-        0.548, 0.557,  0.577, 0.586,  0.607, 0.616,  0.636, 0.645
+        0.430, 0.448,  0.468, 0.478,  0.496, 0.506,  0.524, 0.532,
+        0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640,  0.662, 0.664
       ],
       "terrainYKeyThresholds": [
-        0.98, 0.72,  0.71, 0.56,  0.55, 0.43,  0.42, 0.33,
-        0.32, 0.24,  0.23, 0.18,  0.17, 0.12,  0.11, 0.00
+        0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
+        0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.11,  0.105, 0.00
       ]
     },
     {
-      "code": "canyons_mesas_o2o7half_wide",
-      "comment": "Broad mesas with deep canyons; wider shelves, sheer walls (octave 2 & 7 halved)",
+      "code": "canyons_mesas_o2o7half_wide_v4",
       "hexcolor": "#C28E52",
-      "weight": 31.6667,
-      "terrainOctaves": [0, 0.82, 0.30, 0.48, 0, 0.35, 0.30, 0.04, 0],
-      "terrainOctaveThresholds": [0,0,0,0,0,0.60,0.55,0,0],
+      "weight": 40.714286,
+      "terrainOctaves": [0, 0.82, 0.30, 0.45, 0.00, 0.32, 0.26, 0.04, 0.00, 0.00],
+      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.56, 0.00, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.430, 0.439,   0.570, 0.579,
-        0.700, 0.709,   0.840, 0.849,
-        0.960, 0.969
+        0.430, 0.450,   0.575, 0.588,
+        0.700, 0.710,   0.840, 0.846,
+        0.960, 0.962
       ],
       "terrainYKeyThresholds": [
-        1.00, 0.72,   0.71, 0.52,
-        0.51, 0.36,   0.35, 0.20,
-        0.19, 0.00
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.36,  0.355, 0.20,
+        0.195, 0.00
       ]
     },
     {

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -96,9 +96,9 @@ else:
         landforms = patch_data.get("variants", [])
 
     allowed_codes = {
-        "step_mountains_6tier_o2o7half_wide",
-        "steppedsinkholes_with_risers_o2o7half_wide",
-        "canyons_mesas_o2o7half_wide",
+        "step_mountains_6tier_o2o7half_wide_v4",
+        "steppedsinkholes_risers_o2o7half_wide_v4",
+        "canyons_mesas_o2o7half_wide_v4",
     }
     landforms = [lf for lf in landforms if lf.get("code") in allowed_codes]
 


### PR DESCRIPTION
## Summary
- replace old custom landforms with updated `*_v4` variants and scale weights to occupy 95% of world generation, leaving vanilla landforms at 5%
- update the noise preview script to reference the new landform codes

## Testing
- `python -m py_compile WorldgenMod/generate_noise_images.py && echo OK`
- `python -m json.tool WorldgenMod/SelectedLandforms/data/landforms.json > /dev/null && echo OK`
- `python -m json.tool WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json > /dev/null && echo OK`


------
https://chatgpt.com/codex/tasks/task_b_689b355fbe748323944513615c72369e