### PR TITLE
Replace custom landforms

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -1,55 +1,55 @@
 {
   "code": "landforms",
   "variants": [
-    {
-      "code": "step_mountains_6tier_o2o7half_wide_v4",
-      "hexcolor": "#84A878",
-      "weight": 3.392857,
-      "terrainOctaves": [0, 0.81, 0.365, 0.50, 0.00, 0.35, 0.22, 0.06, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.62, 0.58, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.450,   0.570, 0.582,
-        0.690, 0.700,   0.800, 0.806,
-        0.895, 0.898,   0.952, 0.954
-      ],
-      "terrainYKeyThresholds": [
-        1.00, 0.70,   0.695, 0.52,
-        0.515, 0.40,  0.395, 0.28,
-        0.275, 0.18,  0.175, 0.00
-      ]
-    },
-    {
-      "code": "steppedsinkholes_risers_o2o7half_wide_v4",
-      "hexcolor": "#AAAA00",
-      "weight": 50.892857,
-      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0.00, 1.00, 0.95, 0.425, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.58, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.448,  0.468, 0.478,  0.496, 0.506,  0.524, 0.532,
-        0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640,  0.662, 0.664
-      ],
-      "terrainYKeyThresholds": [
-        0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
-        0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.11,  0.105, 0.00
-      ]
-    },
-    {
-      "code": "canyons_mesas_o2o7half_wide_v4",
-      "hexcolor": "#C28E52",
-      "weight": 40.714286,
-      "terrainOctaves": [0, 0.82, 0.30, 0.45, 0.00, 0.32, 0.26, 0.04, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.56, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.450,   0.575, 0.588,
-        0.700, 0.710,   0.840, 0.846,
-        0.960, 0.962
-      ],
-      "terrainYKeyThresholds": [
-        1.00, 0.72,   0.715, 0.52,
-        0.515, 0.36,  0.355, 0.20,
-        0.195, 0.00
-      ]
-    },
+      {
+        "code": "step_mountains_6tier_smoothbase_taper",
+        "hexcolor": "#84A878",
+        "weight": 3.392857,
+        "terrainOctaves":          [1.00, 0.75, 0.55, 0.00, 0.00, 0.10, 0.06, 0.04, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.65, 0.80, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.450,   0.580, 0.592,
+          0.695, 0.705,   0.800, 0.806,
+          0.895, 0.898,   0.955, 0.957
+        ],
+        "terrainYKeyThresholds": [
+          1.00, 0.70,   0.695, 0.52,
+          0.515, 0.40,  0.395, 0.28,
+          0.275, 0.18,  0.175, 0.00
+        ]
+      },
+      {
+        "code": "steppedsinkholes_risers_smoothbase_wide",
+        "hexcolor": "#AAAA00",
+        "weight": 50.892857,
+        "terrainOctaves":          [0.95, 0.70, 0.50, 0.00, 0.00, 0.95, 0.80, 0.06, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.62, 0.78, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.448,  0.468, 0.480,  0.498, 0.508,  0.524, 0.532,
+          0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640
+        ],
+        "terrainYKeyThresholds": [
+          0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
+          0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.00
+        ]
+      },
+      {
+        "code": "canyons_mesas_smoothbase_wide",
+        "hexcolor": "#C28E52",
+        "weight": 40.714286,
+        "terrainOctaves":          [1.00, 0.72, 0.50, 0.00, 0.00, 0.32, 0.22, 0.05, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.60, 0.80, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.450,   0.580, 0.593,
+          0.705, 0.715,   0.845, 0.851,
+          0.965, 0.967
+        ],
+        "terrainYKeyThresholds": [
+          1.00, 0.72,   0.715, 0.52,
+          0.515, 0.36,  0.355, 0.20,
+          0.195, 0.00
+        ]
+      },
     {
       "code": "largeislands",
       "comment": "lots of water, large island and a few tiny islands",

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -1,55 +1,55 @@
 {
   "code": "landforms",
   "variants": [
-    {
-      "code": "step_mountains_6tier_o2o7half_wide_v4",
-      "hexcolor": "#84A878",
-      "weight": 3.392857,
-      "terrainOctaves": [0, 0.81, 0.365, 0.50, 0.00, 0.35, 0.22, 0.06, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.62, 0.58, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.450,   0.570, 0.582,
-        0.690, 0.700,   0.800, 0.806,
-        0.895, 0.898,   0.952, 0.954
-      ],
-      "terrainYKeyThresholds": [
-        1.00, 0.70,   0.695, 0.52,
-        0.515, 0.40,  0.395, 0.28,
-        0.275, 0.18,  0.175, 0.00
-      ]
-    },
-    {
-      "code": "steppedsinkholes_risers_o2o7half_wide_v4",
-      "hexcolor": "#AAAA00",
-      "weight": 50.892857,
-      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0.00, 1.00, 0.95, 0.425, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.58, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.448,  0.468, 0.478,  0.496, 0.506,  0.524, 0.532,
-        0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640,  0.662, 0.664
-      ],
-      "terrainYKeyThresholds": [
-        0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
-        0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.11,  0.105, 0.00
-      ]
-    },
-    {
-      "code": "canyons_mesas_o2o7half_wide_v4",
-      "hexcolor": "#C28E52",
-      "weight": 40.714286,
-      "terrainOctaves": [0, 0.82, 0.30, 0.45, 0.00, 0.32, 0.26, 0.04, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.56, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.450,   0.575, 0.588,
-        0.700, 0.710,   0.840, 0.846,
-        0.960, 0.962
-      ],
-      "terrainYKeyThresholds": [
-        1.00, 0.72,   0.715, 0.52,
-        0.515, 0.36,  0.355, 0.20,
-        0.195, 0.00
-      ]
-    },
+      {
+        "code": "step_mountains_6tier_smoothbase_taper",
+        "hexcolor": "#84A878",
+        "weight": 3.392857,
+        "terrainOctaves":          [1.00, 0.75, 0.55, 0.00, 0.00, 0.10, 0.06, 0.04, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.65, 0.80, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.450,   0.580, 0.592,
+          0.695, 0.705,   0.800, 0.806,
+          0.895, 0.898,   0.955, 0.957
+        ],
+        "terrainYKeyThresholds": [
+          1.00, 0.70,   0.695, 0.52,
+          0.515, 0.40,  0.395, 0.28,
+          0.275, 0.18,  0.175, 0.00
+        ]
+      },
+      {
+        "code": "steppedsinkholes_risers_smoothbase_wide",
+        "hexcolor": "#AAAA00",
+        "weight": 50.892857,
+        "terrainOctaves":          [0.95, 0.70, 0.50, 0.00, 0.00, 0.95, 0.80, 0.06, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.62, 0.78, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.448,  0.468, 0.480,  0.498, 0.508,  0.524, 0.532,
+          0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640
+        ],
+        "terrainYKeyThresholds": [
+          0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
+          0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.00
+        ]
+      },
+      {
+        "code": "canyons_mesas_smoothbase_wide",
+        "hexcolor": "#C28E52",
+        "weight": 40.714286,
+        "terrainOctaves":          [1.00, 0.72, 0.50, 0.00, 0.00, 0.32, 0.22, 0.05, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.60, 0.80, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.450,   0.580, 0.593,
+          0.705, 0.715,   0.845, 0.851,
+          0.965, 0.967
+        ],
+        "terrainYKeyThresholds": [
+          1.00, 0.72,   0.715, 0.52,
+          0.515, 0.36,  0.355, 0.20,
+          0.195, 0.00
+        ]
+      },
     {
       "code": "largeislands",
       "comment": "lots of water, large island and a few tiny islands",

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -1,55 +1,55 @@
 {
   "code": "landforms",
   "variants": [
-    {
-      "code": "step_mountains_6tier_o2o7half_wide_v4",
-      "hexcolor": "#84A878",
-      "weight": 3.392857,
-      "terrainOctaves": [0, 0.81, 0.365, 0.50, 0.00, 0.35, 0.22, 0.06, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.62, 0.58, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.450,   0.570, 0.582,
-        0.690, 0.700,   0.800, 0.806,
-        0.895, 0.898,   0.952, 0.954
-      ],
-      "terrainYKeyThresholds": [
-        1.00, 0.70,   0.695, 0.52,
-        0.515, 0.40,  0.395, 0.28,
-        0.275, 0.18,  0.175, 0.00
-      ]
-    },
-    {
-      "code": "steppedsinkholes_risers_o2o7half_wide_v4",
-      "hexcolor": "#AAAA00",
-      "weight": 50.892857,
-      "terrainOctaves": [0, 0.22, 0.09, 0.10, 0.00, 1.00, 0.95, 0.425, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.58, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.448,  0.468, 0.478,  0.496, 0.506,  0.524, 0.532,
-        0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640,  0.662, 0.664
-      ],
-      "terrainYKeyThresholds": [
-        0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
-        0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.11,  0.105, 0.00
-      ]
-    },
-    {
-      "code": "canyons_mesas_o2o7half_wide_v4",
-      "hexcolor": "#C28E52",
-      "weight": 40.714286,
-      "terrainOctaves": [0, 0.82, 0.30, 0.45, 0.00, 0.32, 0.26, 0.04, 0.00, 0.00],
-      "terrainOctaveThresholds": [0, 0.00, 0.00, 0.00, 0.00, 0.60, 0.56, 0.00, 0.00, 0.00],
-      "terrainYKeyPositions": [
-        0.430, 0.450,   0.575, 0.588,
-        0.700, 0.710,   0.840, 0.846,
-        0.960, 0.962
-      ],
-      "terrainYKeyThresholds": [
-        1.00, 0.72,   0.715, 0.52,
-        0.515, 0.36,  0.355, 0.20,
-        0.195, 0.00
-      ]
-    },
+      {
+        "code": "step_mountains_6tier_smoothbase_taper",
+        "hexcolor": "#84A878",
+        "weight": 3.392857,
+        "terrainOctaves":          [1.00, 0.75, 0.55, 0.00, 0.00, 0.10, 0.06, 0.04, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.65, 0.80, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.450,   0.580, 0.592,
+          0.695, 0.705,   0.800, 0.806,
+          0.895, 0.898,   0.955, 0.957
+        ],
+        "terrainYKeyThresholds": [
+          1.00, 0.70,   0.695, 0.52,
+          0.515, 0.40,  0.395, 0.28,
+          0.275, 0.18,  0.175, 0.00
+        ]
+      },
+      {
+        "code": "steppedsinkholes_risers_smoothbase_wide",
+        "hexcolor": "#AAAA00",
+        "weight": 50.892857,
+        "terrainOctaves":          [0.95, 0.70, 0.50, 0.00, 0.00, 0.95, 0.80, 0.06, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.62, 0.78, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.448,  0.468, 0.480,  0.498, 0.508,  0.524, 0.532,
+          0.548, 0.560,  0.578, 0.586,  0.606, 0.612,  0.636, 0.640
+        ],
+        "terrainYKeyThresholds": [
+          0.98, 0.72,  0.715, 0.56,  0.555, 0.44,  0.435, 0.34,
+          0.335, 0.25,  0.245, 0.19,  0.185, 0.14,  0.135, 0.00
+        ]
+      },
+      {
+        "code": "canyons_mesas_smoothbase_wide",
+        "hexcolor": "#C28E52",
+        "weight": 40.714286,
+        "terrainOctaves":          [1.00, 0.72, 0.50, 0.00, 0.00, 0.32, 0.22, 0.05, 0.00, 0.00],
+        "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.20, 0.35, 0.60, 0.80, 0.85, 0.00, 0.00],
+        "terrainYKeyPositions": [
+          0.430, 0.450,   0.580, 0.593,
+          0.705, 0.715,   0.845, 0.851,
+          0.965, 0.967
+        ],
+        "terrainYKeyThresholds": [
+          1.00, 0.72,   0.715, 0.52,
+          0.515, 0.36,  0.355, 0.20,
+          0.195, 0.00
+        ]
+      },
     {
       "code": "largeislands",
       "comment": "lots of water, large island and a few tiny islands",

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -96,9 +96,9 @@ else:
         landforms = patch_data.get("variants", [])
 
     allowed_codes = {
-        "step_mountains_6tier_o2o7half_wide_v4",
-        "steppedsinkholes_risers_o2o7half_wide_v4",
-        "canyons_mesas_o2o7half_wide_v4",
+        "step_mountains_6tier_smoothbase_taper",
+        "steppedsinkholes_risers_smoothbase_wide",
+        "canyons_mesas_smoothbase_wide",
     }
     landforms = [lf for lf in landforms if lf.get("code") in allowed_codes]
 


### PR DESCRIPTION
## Summary
- swap in smoothbase landforms and scale their weights to keep 95/5 custom-to-vanilla ratio
- update noise preview script to reference new landform codes

## Testing
- `python -m json.tool WorldgenMod/SelectedLandforms/data/landforms.json`
- `python -m json.tool WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json`
- `python -m json.tool WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json`
- `python -m py_compile WorldgenMod/generate_noise_images.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b3913a76c8323b38d6d97234a0739