### PR TITLE
feat: update landforms and preview script

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/game/worldgen/landforms.json
@@ -2,62 +2,45 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step_mountains_4changes_compact_irregular",
+      "code": "step_mountains_6tier_bestof_balanced",
+      "comment": "6 crisp plateaus with added detail; shelves not paper-thin",
       "hexcolor": "#84A878",
-      "weight": 4,
-      "terrainOctaves": [
-        0.3,
-        0.22,
-        0.16,
-        0.12,
-        0.08,
-        0.18,
-        0.12,
-        0.05,
-        0.0,
-        0.0
-      ],
-      "terrainOctaveThresholds": [
-        0.0,
-        0.0,
-        0.0,
-        0.22,
-        0.3,
-        0.52,
-        0.68,
-        0.82,
-        0.0,
-        0.0
-      ],
+      "weight": 7.916666666666667,
+      "terrainOctaves": [0.00, 0.81, 0.28, 0.58, 0.00, 0.30, 0.22, 0.05, 0.00, 0.00],
+      "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.10, 0.25, 0.58, 0.72, 0.84, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.43,
-        0.436,
-        0.596,
-        0.6,
-        0.717,
-        0.721,
-        0.816,
-        0.818,
-        0.9,
-        0.901
+        0.430, 0.442,   0.565, 0.575,
+        0.680, 0.688,   0.790, 0.796,
+        0.885, 0.889,   0.945, 0.947
       ],
       "terrainYKeyThresholds": [
-        1.0,
-        0.73,
-        0.729,
-        0.56,
-        0.559,
-        0.41,
-        0.409,
-        0.3,
-        0.299,
-        0.0
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.39,  0.385, 0.27,
+        0.265, 0.16,  0.155, 0.00
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_bestof_xdetail",
+      "comment": "6 plateaus with more micro-variation, still preserving shelf width",
+      "hexcolor": "#84A878",
+      "weight": 7.916666666666667,
+      "terrainOctaves": [0.00, 0.81, 0.30, 0.60, 0.00, 0.36, 0.28, 0.08, 0.02, 0.00],
+      "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.12, 0.26, 0.62, 0.76, 0.86, 0.90, 0.00],
+      "terrainYKeyPositions": [
+        0.430, 0.442,   0.565, 0.575,
+        0.680, 0.688,   0.790, 0.796,
+        0.885, 0.889,   0.945, 0.947
+      ],
+      "terrainYKeyThresholds": [
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.39,  0.385, 0.27,
+        0.265, 0.16,  0.155, 0.00
       ]
     },
     {
       "code": "steppedsinkholes_4changes_compact_irregular",
       "hexcolor": "#AAAA00",
-      "weight": 5,
+      "weight": 39.583333333333336,
       "terrainOctaves": [
         0.28,
         0.2,
@@ -110,7 +93,7 @@
     {
       "code": "canyons_4changes_compact_irregular",
       "hexcolor": "#C28E52",
-      "weight": 5,
+      "weight": 39.583333333333336,
       "terrainOctaves": [
         0.4,
         0.3,

--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2,62 +2,45 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step_mountains_4changes_compact_irregular",
+      "code": "step_mountains_6tier_bestof_balanced",
+      "comment": "6 crisp plateaus with added detail; shelves not paper-thin",
       "hexcolor": "#84A878",
-      "weight": 4,
-      "terrainOctaves": [
-        0.3,
-        0.22,
-        0.16,
-        0.12,
-        0.08,
-        0.18,
-        0.12,
-        0.05,
-        0.0,
-        0.0
-      ],
-      "terrainOctaveThresholds": [
-        0.0,
-        0.0,
-        0.0,
-        0.22,
-        0.3,
-        0.52,
-        0.68,
-        0.82,
-        0.0,
-        0.0
-      ],
+      "weight": 7.916666666666667,
+      "terrainOctaves": [0.00, 0.81, 0.28, 0.58, 0.00, 0.30, 0.22, 0.05, 0.00, 0.00],
+      "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.10, 0.25, 0.58, 0.72, 0.84, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.43,
-        0.436,
-        0.596,
-        0.6,
-        0.717,
-        0.721,
-        0.816,
-        0.818,
-        0.9,
-        0.901
+        0.430, 0.442,   0.565, 0.575,
+        0.680, 0.688,   0.790, 0.796,
+        0.885, 0.889,   0.945, 0.947
       ],
       "terrainYKeyThresholds": [
-        1.0,
-        0.73,
-        0.729,
-        0.56,
-        0.559,
-        0.41,
-        0.409,
-        0.3,
-        0.299,
-        0.0
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.39,  0.385, 0.27,
+        0.265, 0.16,  0.155, 0.00
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_bestof_xdetail",
+      "comment": "6 plateaus with more micro-variation, still preserving shelf width",
+      "hexcolor": "#84A878",
+      "weight": 7.916666666666667,
+      "terrainOctaves": [0.00, 0.81, 0.30, 0.60, 0.00, 0.36, 0.28, 0.08, 0.02, 0.00],
+      "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.12, 0.26, 0.62, 0.76, 0.86, 0.90, 0.00],
+      "terrainYKeyPositions": [
+        0.430, 0.442,   0.565, 0.575,
+        0.680, 0.688,   0.790, 0.796,
+        0.885, 0.889,   0.945, 0.947
+      ],
+      "terrainYKeyThresholds": [
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.39,  0.385, 0.27,
+        0.265, 0.16,  0.155, 0.00
       ]
     },
     {
       "code": "steppedsinkholes_4changes_compact_irregular",
       "hexcolor": "#AAAA00",
-      "weight": 5,
+      "weight": 39.583333333333336,
       "terrainOctaves": [
         0.28,
         0.2,
@@ -110,7 +93,7 @@
     {
       "code": "canyons_4changes_compact_irregular",
       "hexcolor": "#C28E52",
-      "weight": 5,
+      "weight": 39.583333333333336,
       "terrainOctaves": [
         0.4,
         0.3,

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2,62 +2,45 @@
   "code": "landforms",
   "variants": [
     {
-      "code": "step_mountains_4changes_compact_irregular",
+      "code": "step_mountains_6tier_bestof_balanced",
+      "comment": "6 crisp plateaus with added detail; shelves not paper-thin",
       "hexcolor": "#84A878",
-      "weight": 4,
-      "terrainOctaves": [
-        0.3,
-        0.22,
-        0.16,
-        0.12,
-        0.08,
-        0.18,
-        0.12,
-        0.05,
-        0.0,
-        0.0
-      ],
-      "terrainOctaveThresholds": [
-        0.0,
-        0.0,
-        0.0,
-        0.22,
-        0.3,
-        0.52,
-        0.68,
-        0.82,
-        0.0,
-        0.0
-      ],
+      "weight": 7.916666666666667,
+      "terrainOctaves": [0.00, 0.81, 0.28, 0.58, 0.00, 0.30, 0.22, 0.05, 0.00, 0.00],
+      "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.10, 0.25, 0.58, 0.72, 0.84, 0.00, 0.00],
       "terrainYKeyPositions": [
-        0.43,
-        0.436,
-        0.596,
-        0.6,
-        0.717,
-        0.721,
-        0.816,
-        0.818,
-        0.9,
-        0.901
+        0.430, 0.442,   0.565, 0.575,
+        0.680, 0.688,   0.790, 0.796,
+        0.885, 0.889,   0.945, 0.947
       ],
       "terrainYKeyThresholds": [
-        1.0,
-        0.73,
-        0.729,
-        0.56,
-        0.559,
-        0.41,
-        0.409,
-        0.3,
-        0.299,
-        0.0
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.39,  0.385, 0.27,
+        0.265, 0.16,  0.155, 0.00
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_bestof_xdetail",
+      "comment": "6 plateaus with more micro-variation, still preserving shelf width",
+      "hexcolor": "#84A878",
+      "weight": 7.916666666666667,
+      "terrainOctaves": [0.00, 0.81, 0.30, 0.60, 0.00, 0.36, 0.28, 0.08, 0.02, 0.00],
+      "terrainOctaveThresholds": [0.00, 0.00, 0.00, 0.12, 0.26, 0.62, 0.76, 0.86, 0.90, 0.00],
+      "terrainYKeyPositions": [
+        0.430, 0.442,   0.565, 0.575,
+        0.680, 0.688,   0.790, 0.796,
+        0.885, 0.889,   0.945, 0.947
+      ],
+      "terrainYKeyThresholds": [
+        1.00, 0.72,   0.715, 0.52,
+        0.515, 0.39,  0.385, 0.27,
+        0.265, 0.16,  0.155, 0.00
       ]
     },
     {
       "code": "steppedsinkholes_4changes_compact_irregular",
       "hexcolor": "#AAAA00",
-      "weight": 5,
+      "weight": 39.583333333333336,
       "terrainOctaves": [
         0.28,
         0.2,
@@ -110,7 +93,7 @@
     {
       "code": "canyons_4changes_compact_irregular",
       "hexcolor": "#C28E52",
-      "weight": 5,
+      "weight": 39.583333333333336,
       "terrainOctaves": [
         0.4,
         0.3,

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -96,7 +96,8 @@ else:
         landforms = patch_data.get("variants", [])
 
     allowed_codes = {
-        "step_mountains_4changes_compact_irregular",
+        "step_mountains_6tier_bestof_balanced",
+        "step_mountains_6tier_bestof_xdetail",
         "steppedsinkholes_4changes_compact_irregular",
         "canyons_4changes_compact_irregular",
     }


### PR DESCRIPTION
## Summary
- replace old step mountain landform with balanced and extra-detail variants
- scale custom landform weights to maintain ~95% custom worldgen
- update preview script to recognize new landforms

## Testing
- `python -m json.tool WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json`
- `python -m py_compile WorldgenMod/generate_noise_images.py`
- `python WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json` weight check


------
https://chatgpt.com/codex/tasks/task_b_689b78c608d083239de493f678a02fd3