### PR TITLE
Add custom step mountain landforms

### DIFF
--- a/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
+++ b/WorldgenMod/SelectedLandforms/assets/selectedlandforms/patches/landforms.json
@@ -2561,6 +2561,192 @@
           ]
         }
       ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4all",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_med2",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.45, 0.25, 0.25, 0, 0.25, 0.2, 0.03, 0],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4_123",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0.4, 0.41, 0.45, 0, 0, 0, 0, 0, 0],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4_456",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0, 0, 0.4, 0.4, 0.4, 0, 0, 0],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4_789",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0, 0, 0, 0, 0, 0.4, 0.4, 0.4],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4_23_2_5_2_7",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.4, 0.4, 0, 0.2, 0, 0.2, 0, 0],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
     }
   ]
 }

--- a/WorldgenMod/SelectedLandforms/data/landforms.json
+++ b/WorldgenMod/SelectedLandforms/data/landforms.json
@@ -2561,6 +2561,192 @@
           ]
         }
       ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4all",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_med2",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.45, 0.25, 0.25, 0, 0.25, 0.2, 0.03, 0],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4_123",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0.4, 0.41, 0.45, 0, 0, 0, 0, 0, 0],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4_456",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0, 0, 0.4, 0.4, 0.4, 0, 0, 0],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4_789",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0, 0, 0, 0, 0, 0.4, 0.4, 0.4],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
+    },
+    {
+      "code": "step_mountains_6tier_test_4_23_2_5_2_7",
+      "comment": "Six flat plateaus with sheer cliffs; octave 2 & 7 halved",
+      "hexcolor": "#84A878",
+      "weight": 1,
+      "terrainOctaves": [0, 0.4, 0.4, 0, 0.2, 0, 0.2, 0, 0],
+      "terrainYKeyPositions": [
+        0.43, 0.435,
+        0.55,
+        0.553,
+        0.65,
+        0.653,
+        0.75,
+        0.753,
+        0.85,
+        0.853,
+        0.93, 0.933
+      ],
+      "terrainYKeyThresholds": [
+        1.0, 0.72,
+        0.7,
+        0.52,
+        0.5,
+        0.38,
+        0.36,
+        0.26,
+        0.24,
+        0.14,
+        0.13, 0.0
+      ]
     }
   ]
 }

--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -103,6 +103,12 @@ else:
         "step_mountains_6tier_test_large_123",
         "step_mountains_6tier_test_largemid_456",
         "step_mountains_6tier_test_smallall",
+        "step_mountains_6tier_test_4all",
+        "step_mountains_6tier_med2",
+        "step_mountains_6tier_test_4_123",
+        "step_mountains_6tier_test_4_456",
+        "step_mountains_6tier_test_4_789",
+        "step_mountains_6tier_test_4_23_2_5_2_7",
     }
     landforms = [lf for lf in landforms if lf.get("code") in allowed_codes]
 


### PR DESCRIPTION
## Summary
- add six new `step_mountains` landform variants for testing
- include new landform codes in noise preview script

## Testing
- `python -m json.tool WorldgenMod/SelectedLandforms/data/landforms.json`
- `python -m py_compile WorldgenMod/generate_noise_images.py`


------
https://chatgpt.com/codex/tasks/task_b_689b84ae4bb88323ac7d7e40dbe0e2be