### PR TITLE
Render all selected landforms in noise preview script

### DIFF
--- a/WorldgenMod/generate_noise_images.py
+++ b/WorldgenMod/generate_noise_images.py
@@ -95,23 +95,6 @@ else:
     else:
         landforms = patch_data.get("variants", [])
 
-    allowed_codes = {
-        "step_mountains_6tier_test_control",
-        "step_mountains_4tiera",
-        "step_mountains_6tier_test_small_2_big_789",
-        "step_mountains_6tier_test_Large All",
-        "step_mountains_6tier_test_large_123",
-        "step_mountains_6tier_test_largemid_456",
-        "step_mountains_6tier_test_smallall",
-        "step_mountains_6tier_test_4all",
-        "step_mountains_6tier_med2",
-        "step_mountains_6tier_test_4_123",
-        "step_mountains_6tier_test_4_456",
-        "step_mountains_6tier_test_4_789",
-        "step_mountains_6tier_test_4_23_2_5_2_7",
-    }
-    landforms = [lf for lf in landforms if lf.get("code") in allowed_codes]
-
     if TARGET_CODE:
         landforms = [lf for lf in landforms if lf.get("code") == TARGET_CODE]
 


### PR DESCRIPTION
## Summary
- Allow `generate_noise_images.py` to render every landform defined in a SelectedLandforms patch by removing the hardcoded whitelist.

## Testing
- `python -m py_compile WorldgenMod/generate_noise_images.py`
- `python WorldgenMod/generate_noise_images.py --size 4 --code step_mountains_6tier_test_4_456`

------
https://chatgpt.com/codex/tasks/task_b_68a2fe781a8c83239a433aa363536784